### PR TITLE
Use yaml.safe_load instead of yaml.load.

### DIFF
--- a/pysmo/core/sac/sacheader.py
+++ b/pysmo/core/sac/sacheader.py
@@ -29,7 +29,7 @@ Copyright (c) 2018 Simon Lloyd
 
 # Load SAC header definitions from yaml file and store them in dicts
 with open(os.path.join(os.path.dirname(__file__), 'sacheader.yml'), 'r') as stream:
-    _HEADER_DEFS = yaml.load(stream)
+    _HEADER_DEFS = yaml.safe_load(stream)
 
 # Create dictionary of different header types (float, integer, enumerated, logical,
 # alphanumeric, auxilary). This provides respective defaults etc.


### PR DESCRIPTION
This change mitigates the issue in CVE-2017-18342.