### PR TITLE
Update readme to fit in better with the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,53 +4,25 @@
 [![Documentation Status](https://readthedocs.org/projects/pysmo/badge/?version=latest)](https://pysmo.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/pysmo/pysmo/branch/master/graph/badge.svg?token=ZsHTBN4rxF)](https://codecov.io/gh/pysmo/pysmo)
 [![PyPI](https://img.shields.io/pypi/v/pysmo)](https://pypi.org/project/pysmo/)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pysmo)
 
-Pysmo
-=====
+Pysmo offers simple data types for seismologists to write code with. Instead
+of working with one big class containing all kinds of data, psymo uses separate,
+narrowly defined classes that are more meaningful when describing things that
+exist in the real world. The type definitions are not tied to any particular
+file format, and thus free users from needing to adhere to Python data structures
+often dictated by a rigid underlying file format.
 
-The pysmo package provides simple tools for seismologists to solve problems in a pythonic fashion.
+Together with these data types, pysmo provides a growing library of essential
+functions that benefit from using these types. Programming with pysmo results
+in code that is:
 
+  - using modern Python concepts.
+  - easy to write and understand.
+  - both portable and future proof.
 
-Quickstart
-----------
-To install the stable version of pysmo run the following command in a terminal:
-
-```shell
-$ pip install pysmo
-```
-
-Pre-release versions of pysmo can be installed by running:
-
-```shell
-$ pip install pysmo --pre
-```
-
-Finally, to install the current ``master`` branch directly from Github run:
-
-```shell
-$ pip install git+https://github.com/pysmo/pysmo
-```
-
-Pysmo can then be used in a python script or the python shell directly:
-
-
-```python
->>> from pysmo import SAC
->>> seismogram = SAC.from_file('file.sac')
->>> print(seismogram.delta)
-0.02500000037252903
->>> print(seismogram.data)
-[-2.987490077543953e-08, -2.983458813332618e-08, ...
->>> help(SAC)
-Help on class SAC in module pysmo object:
-
-...
-```
-Documentation
--------------
-
-The complete pysmo documentation is available at https://pysmo.readthedocs.io/
+Pysmo itself is designed to be modular and easy to expand without interfering
+with the existing code base, making it straightforward to incorporate user
+contributions.
 
 Contributors
 ------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,9 @@ Welcome to the pysmo documentation!
 .. include:: readme.md
    :parser: myst_parser.sphinx_
 
+Contents
+--------
+
 .. toctree::
    :maxdepth: 2
    :caption: First Steps:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -20,8 +20,12 @@ can be easily installed using the ``pip`` module::
 
   $ python3 -m pip install pysmo
 
-If desired, the latest development version of Pysmo can be installed *instead* of the
-stable release::
+Pre-release versions of pysmo can be installed with the `--pre` flag::
+
+  $ python3 -m pip install pysmo --pre
+
+Finally, the latest development version of Pysmo can be installed directly from Github by
+running::
 
    $ python -m pip install git+https://github.com/pysmo/pysmo
 


### PR DESCRIPTION
Readme is now also on the first page of the sphinx generated documentation.

Closes #68 

<!-- readthedocs-preview pysmo start -->
----
:books: Documentation preview :books:: https://pysmo--68.org.readthedocs.build/en/68/

<!-- readthedocs-preview pysmo end -->