### PR TITLE
Bug fix in normalize function

### DIFF
--- a/pysmo/functions/normalize.py
+++ b/pysmo/functions/normalize.py
@@ -21,7 +21,7 @@ def normalize(seismogram: Seismogram) -> Seismogram:
         True
     """
     seis = copy.deepcopy(seismogram)
-    norm = np.max(seis.data)
-    seis.data /= np.abs(norm)
+    norm = np.max(np.abs(seis.data))
+    seis.data /= norm
 
     return seis


### PR DESCRIPTION
Fixed a bug in normalize function. np.abs() needs be done before calling np.max() to ensure that the negative values are handled correctly. 

<!-- readthedocs-preview pysmo start -->
----
:books: Documentation preview :books:: https://pysmo--81.org.readthedocs.build/en/81/

<!-- readthedocs-preview pysmo end -->