### PR TITLE
Add lib/defaults.py

### DIFF
--- a/pysmo/classes/mini.py
+++ b/pysmo/classes/mini.py
@@ -1,7 +1,8 @@
 import numpy as np
 from dataclasses import dataclass, field
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 from typing import Optional
+from pysmo.lib.defaults import SEISMOGRAM_DEFAULTS
 
 
 @dataclass
@@ -22,7 +23,7 @@ class MiniSeismogram:
         True
     """
 
-    begin_time: datetime = datetime.fromtimestamp(0, tz=timezone.utc)
+    begin_time: datetime = SEISMOGRAM_DEFAULTS.begin_time
     """Seismogram begin time.
 
     The :py:attr:`MiniSeismogram.begin_time` attribute is the (absolute) time of the
@@ -30,7 +31,7 @@ class MiniSeismogram:
     If a new instance is created without specifiying the begin time, Unix time 0 is used.
     """
 
-    sampling_rate: float = 1
+    sampling_rate: float = SEISMOGRAM_DEFAULTS.sampling_rate
     """Seismogram sampling rate.
 
     The :py:attr:`MiniSeismogram.sampling_rate` attribute is the sampling rate of the

--- a/pysmo/lib/README.md
+++ b/pysmo/lib/README.md
@@ -1,0 +1,9 @@
+# Pysmo lib folder
+
+**Table of Contents**
+
+- [defaults.py](#defaults.py)
+
+## defaults.py
+
+The [`defaults.py`](defaults.py) file contains default values used throughout pysmo.

--- a/pysmo/lib/defaults.py
+++ b/pysmo/lib/defaults.py
@@ -1,0 +1,15 @@
+"""
+Defaults for various pysmo functions/classes.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+@dataclass(frozen=True)
+class _SEISMOGRAM_DEFAULTS:
+    begin_time: datetime = datetime.fromtimestamp(0, tz=timezone.utc)
+    sampling_rate: float = 1
+
+
+SEISMOGRAM_DEFAULTS = _SEISMOGRAM_DEFAULTS()

--- a/tests/classes/test_mini.py
+++ b/tests/classes/test_mini.py
@@ -8,6 +8,7 @@ from pysmo import (
     MiniStation,
     MiniHypocenter
 )
+from pysmo.lib.defaults import SEISMOGRAM_DEFAULTS
 
 
 def test_MiniSeismogram() -> None:
@@ -18,15 +19,15 @@ def test_MiniSeismogram() -> None:
     assert isinstance(my_seismogram, Seismogram)
 
     # Check defaults
-    assert my_seismogram.begin_time.year == 1970
-    assert my_seismogram.begin_time.month == 1
-    assert my_seismogram.begin_time.day == 1
-    assert my_seismogram.begin_time.hour == 0
-    assert my_seismogram.begin_time.minute == 0
-    assert my_seismogram.begin_time.second == 0
-    assert my_seismogram.begin_time.microsecond == 0
+    assert my_seismogram.begin_time.year == SEISMOGRAM_DEFAULTS.begin_time.year == 1970
+    assert my_seismogram.begin_time.month == SEISMOGRAM_DEFAULTS.begin_time.month == 1
+    assert my_seismogram.begin_time.day == SEISMOGRAM_DEFAULTS.begin_time.day == 1
+    assert my_seismogram.begin_time.hour == SEISMOGRAM_DEFAULTS.begin_time.hour == 0
+    assert my_seismogram.begin_time.minute == SEISMOGRAM_DEFAULTS.begin_time.minute == 0
+    assert my_seismogram.begin_time.second == SEISMOGRAM_DEFAULTS.begin_time.second == 0
+    assert my_seismogram.begin_time.microsecond == SEISMOGRAM_DEFAULTS.begin_time.microsecond == 0
+    assert my_seismogram.sampling_rate == SEISMOGRAM_DEFAULTS.sampling_rate == 1
     assert my_seismogram.data.size == 0
-    assert my_seismogram.sampling_rate == 1
     assert len(my_seismogram) == 0
     assert my_seismogram.id is None
 


### PR DESCRIPTION
Defaults used throughout pysmo should be kept in one place.

<!-- readthedocs-preview pysmo start -->
----
:books: Documentation preview :books:: https://pysmo--95.org.readthedocs.build/en/95/

<!-- readthedocs-preview pysmo end -->