### PR TITLE
Create tox venv without docs packages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ depends =
   report: py310, py311
 allowlist_externals = poetry
 commands_pre =
-  poetry install --no-root --sync
+  poetry install -v --no-root --sync --without docs
 commands =
   poetry run py.test tests --mpl --mypy --cov=pysmo --cov-append --cov-report=term-missing
 


### PR DESCRIPTION


<!-- readthedocs-preview pysmo start -->
----
:books: Documentation preview :books:: https://pysmo--98.org.readthedocs.build/en/98/

<!-- readthedocs-preview pysmo end -->