### PR TITLE
Issue #65: providing error message from IRIS service

### DIFF
--- a/pysmo/io/sacio/sacio.py
+++ b/pysmo/io/sacio/sacio.py
@@ -369,6 +369,8 @@ class _SacIO(metaclass=_SacMeta):
         params = urllib.parse.urlencode(kwargs, doseq=False)
         url = f"{base}?{params}"
         response = requests.get(url)
+        if not response:
+            raise ValueError(response.content.decode("utf-8"))
         zip = zipfile.ZipFile(io.BytesIO(response.content))
         result = {}
         for name in zip.namelist():

--- a/pysmo/io/sacio/sacio.py
+++ b/pysmo/io/sacio/sacio.py
@@ -27,7 +27,7 @@ import urllib.parse
 import zipfile
 import warnings
 import numpy as np
-from typing import Union, Optional, Any
+from typing import Union, Any
 from typing_extensions import Self
 from .sacheader import HEADER_FIELDS, SacHeaderFactory
 
@@ -342,7 +342,7 @@ class _SacIO(metaclass=_SacMeta):
 
     @classmethod
     def from_iris(cls, net: str, sta: str, cha: str, loc: str, force_single_result: bool = False,
-                  **kwargs: Any) -> Union[Self, Optional[dict[str, Self]]]:
+                  **kwargs: Any) -> Union[Self, dict[str, Self], None]:
         """
         Create a list of SAC instances from a single IRIS
         request using the output format as "sac.zip".

--- a/tests/io/test_sacio.py
+++ b/tests/io/test_sacio.py
@@ -342,3 +342,60 @@ def test_iris_service() -> None:
         demean="true",
         force_single_result=True)
     assert mysac.npts == 144001  # type: ignore
+
+
+@pytest.mark.depends(on=['test_file_and_buffer'])
+def test_iris_service_params_error() -> None:
+    try:
+        mysac = SacIO.from_iris(
+            net="XX",
+            sta="XXXX",
+            cha="XXX",
+            loc="XX",
+            start="2012-01-11T11:11:11",
+            duration=1 * 60 * 60,
+            scale="AUTO",
+            demean="true",
+            force_single_result=True)
+        assert False
+    except ValueError as error:
+        assert str(error).startswith("Error 404: Not Found")
+
+
+@pytest.mark.depends(on=['test_file_and_buffer'])
+def test_iris_service_multi_result() -> None:
+    mysacs = SacIO.from_iris(
+        net="IU",
+        sta="MAKZ",
+        cha="HHZ",
+        loc="00",
+        start="2015-09-09T15:00:00",
+        duration=1 * 60 * 60,
+        scale="AUTO",
+        demean="true",
+        force_single_result=False)
+    assert len(mysacs) == 4
+    data = [
+        ("IU.MAKZ.00.HHZ.D.2015.252.150941.SAC", 36790),
+        ("IU.MAKZ.00.HHZ.D.2015.252.152559.SAC", 39196),
+        ("IU.MAKZ.00.HHZ.D.2015.252.154438.SAC", 40349),
+        ("IU.MAKZ.00.HHZ.D.2015.252.155301.SAC", 37711)
+    ]
+
+    for name, npts in data:
+        assert mysacs[name].npts == npts
+
+
+@pytest.mark.depends(on=['test_file_and_buffer'])
+def test_iris_service_multi_result_forced() -> None:
+    mysacs = SacIO.from_iris(
+        net="IU",
+        sta="MAKZ",
+        cha="HHZ",
+        loc="00",
+        start="2015-09-09T15:00:00",
+        duration=1 * 60 * 60,
+        scale="AUTO",
+        demean="true",
+        force_single_result=True)
+    assert mysacs.npts == 36790

--- a/tests/io/test_sacio.py
+++ b/tests/io/test_sacio.py
@@ -374,6 +374,7 @@ def test_iris_service_multi_result() -> None:
         scale="AUTO",
         demean="true",
         force_single_result=False)
+    assert isinstance(mysacs, dict)
     assert len(mysacs) == 4
     data = [
         ("IU.MAKZ.00.HHZ.D.2015.252.150941.SAC", 36790),
@@ -383,6 +384,7 @@ def test_iris_service_multi_result() -> None:
     ]
 
     for name, npts in data:
+        assert isinstance(mysacs[name], SacIO)
         assert mysacs[name].npts == npts
 
 
@@ -398,4 +400,5 @@ def test_iris_service_multi_result_forced() -> None:
         scale="AUTO",
         demean="true",
         force_single_result=True)
+    assert isinstance(mysacs, SacIO)
     assert mysacs.npts == 36790

--- a/tests/io/test_sacio.py
+++ b/tests/io/test_sacio.py
@@ -347,7 +347,7 @@ def test_iris_service() -> None:
 @pytest.mark.depends(on=['test_file_and_buffer'])
 def test_iris_service_params_error() -> None:
     try:
-        mysac = SacIO.from_iris(
+        SacIO.from_iris(
             net="XX",
             sta="XXXX",
             cha="XXX",


### PR DESCRIPTION
When IRIS service responses with 4x or 5x error, _SacIO.from_iris raises a ValueError with the message description.

<!-- readthedocs-preview pysmo start -->
----
:books: Documentation preview :books:: https://pysmo--105.org.readthedocs.build/en/105/

<!-- readthedocs-preview pysmo end -->