### PR TITLE
fix: use paramspec (for now) on value_not_none decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ nohup.out
 .nfs*
 docs/source/apidocs/
 .tox
+.idea
+blah.py
+foo.py
+bar.py

--- a/pysmo/lib/decorators.py
+++ b/pysmo/lib/decorators.py
@@ -1,21 +1,23 @@
-from typing import Callable, TypeVar
+from typing import Callable, TypeVar, ParamSpec
 from functools import wraps
 
-Instance = TypeVar('Instance')
-Value = TypeVar('Value')
-ReturnType = TypeVar('ReturnType')
+T = TypeVar('T')
+P = ParamSpec('P')
 
 
-def value_not_none(function: Callable[[Instance, Value], ReturnType]) -> Callable[[Instance, Value], ReturnType]:
+# HACK: Since the args are known this should work without
+# ParamSpec (i.e. using only TypVar).
+def value_not_none(function: Callable[P, T]) -> Callable[P, T]:
     """Decorator to prevent the value in properties from being None"""
 
     @wraps(function)
-    def decorator(instance: Instance, value: Value) -> ReturnType:
+    def decorator(*args: P.args, **kwargs: P.kwargs) -> T:
+        instance, value = args
         if value is None:
             raise TypeError(
                 f"{instance.__class__.__name__}.{function.__name__} may not be of None type."
             )
-        return function(instance, value)
+        return function(*args, **kwargs)
     return decorator
 
 


### PR DESCRIPTION


<!-- readthedocs-preview pysmo start -->
----
:books: Documentation preview :books:: https://pysmo--132.org.readthedocs.build/en/132/

<!-- readthedocs-preview pysmo end -->