### PR TITLE
Bugfix importerror

### DIFF
--- a/pysmo/classes/mini.py
+++ b/pysmo/classes/mini.py
@@ -5,10 +5,12 @@ are used as output objects in functions. The classes are all named using the
 pattern `Mini<Type>`. Thus the [`Seismogram`][pysmo.types.Seismogram] type has
 a corresponding [`MiniSeismogram`][pysmo.classes.mini.MiniSeismogram] class.
 """
-try:
+import sys 
+if sys.version_info >= (3, 11): 
     from typing import Self  # py311+
-except ImportError:
+else:
     from typing_extensions import Self  # py310
+
 from pysmo.lib.defaults import SEISMOGRAM_DEFAULTS
 from pysmo.lib.functions import _normalize, _detrend, _resample
 from pysmo import Seismogram

--- a/pysmo/classes/mini.py
+++ b/pysmo/classes/mini.py
@@ -5,12 +5,12 @@ are used as output objects in functions. The classes are all named using the
 pattern `Mini<Type>`. Thus the [`Seismogram`][pysmo.types.Seismogram] type has
 a corresponding [`MiniSeismogram`][pysmo.classes.mini.MiniSeismogram] class.
 """
-import sys 
-if sys.version_info >= (3, 11): 
+import sys
+
+if sys.version_info >= (3, 11):
     from typing import Self  # py311+
 else:
     from typing_extensions import Self  # py310
-
 from pysmo.lib.defaults import SEISMOGRAM_DEFAULTS
 from pysmo.lib.functions import _normalize, _detrend, _resample
 from pysmo import Seismogram

--- a/pysmo/lib/io/sacio.py
+++ b/pysmo/lib/io/sacio.py
@@ -5,11 +5,13 @@ from pysmo.lib.exceptions import SacHeaderUndefined
 from pysmo.lib.functions import _azdist
 from pysmo.lib.defaults import SACIO_DEFAULTS
 
-try:
+import sys 
+if sys.version_info >= (3, 11):
     from typing import Any, Self  # py311+
-except ImportError:
+else:
     from typing import Any
     from typing_extensions import Self  # py310
+    
 from attrs import define, field, validators, Attribute, converters
 from attrs_strict import type_validator
 from enum import Enum

--- a/pysmo/lib/io/sacio.py
+++ b/pysmo/lib/io/sacio.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 from pysmo.lib.exceptions import SacHeaderUndefined
 from pysmo.lib.functions import _azdist
 from pysmo.lib.defaults import SACIO_DEFAULTS
+import sys
 
-import sys 
 if sys.version_info >= (3, 11):
     from typing import Any, Self  # py311+
 else:
     from typing import Any
     from typing_extensions import Self  # py310
-    
 from attrs import define, field, validators, Attribute, converters
 from attrs_strict import type_validator
 from enum import Enum

--- a/utils/templates/sacio-template.py.j2
+++ b/utils/templates/sacio-template.py.j2
@@ -4,9 +4,11 @@ from __future__ import annotations
 from pysmo.lib.exceptions import SacHeaderUndefined
 from pysmo.lib.functions import _azdist
 from pysmo.lib.defaults import SACIO_DEFAULTS
-try:
+import sys
+
+if sys.version_info >= (3, 11):
     from typing import Any, Self  # py311+
-except ImportError:
+else:
     from typing import Any
     from typing_extensions import Self  # py310
 from attrs import define, field, validators, Attribute, converters


### PR DESCRIPTION
Fix for typing_extensions import error. Used the approach recommended by mypy (https://mypy.readthedocs.io/en/stable/runtime_troubles.html#using-new-additions-to-the-typing-module) which uses if/else statements to check for Python version and chooses the appropriate import instead of try/except blocks. 


<!-- readthedocs-preview pysmo start -->
----
:books: Documentation preview :books:: https://pysmo--136.org.readthedocs.build/en/136/

<!-- readthedocs-preview pysmo end -->