### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,8 @@
 name: unit tests
 
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/pysmo/pysmo/security/code-scanning/5](https://github.com/pysmo/pysmo/security/code-scanning/5)

The best fix is to explicitly set the minimal required permissions at the root of the workflow (`permissions:` directly beneath the workflow `name:` or after `on:`), so all jobs inherit these restrictions by default. For this workflow, `contents: read` is the minimal permission needed for upload/download artifacts and code checkouts; neither uploading artifacts nor uploading to Codecov require write access. Root-level permissions are easier to manage and audit than job-level settings unless a specific job requires broader permissions, which does not apply here. The change consists of inserting a permissions stanza after the workflow `name` or after the `on` key (line 3/4), as per GitHub Actions documentation, e.g.:
```yaml
permissions:
  contents: read
```
No imports, definitions, or other changes are required; only the one YAML insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--211.org.readthedocs.build/en/211/

<!-- readthedocs-preview pysmo end -->