### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/pysmo/pysmo/security/code-scanning/3](https://github.com/pysmo/pysmo/security/code-scanning/3)

To fix this problem, add an explicit `permissions` block that grants only the minimum required permissions at the top level of the workflow (i.e., at the root of the YAML file, above jobs:), so it applies to all jobs unless overridden. If the workflow does not need to write to repository contents, pull requests, or issues (which appears to be the case as it's only building and publishing Python packages), then setting `permissions: contents: read` is sufficient and safest. If any step in the workflow requires more privileges (such as write access to releases or packages), those can be added specifically as needed (but the shown jobs do not seem to require them).

The edit should be:  
- Add the following below the `name:` line and above the `on:` block:
  ```yaml
  permissions:
    contents: read
  ```
- No methods, definitions, or imports are required, just this YAML addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--212.org.readthedocs.build/en/212/

<!-- readthedocs-preview pysmo end -->