### PR TITLE
fix(sacpz): tolerate Fortran D/d exponents in SAC PZ text

### DIFF
--- a/src/pysmo/classes/_sacpz.py
+++ b/src/pysmo/classes/_sacpz.py
@@ -138,6 +138,24 @@ class SacPZ:
         Tip: See Also
             [`SacPZ.all_from_text`][pysmo.classes.SacPZ.all_from_text]: Parse
             a bulk/concatenated multi-record text body.
+
+        Examples:
+            Reading a SAC PZ file already saved to disk — the common case for
+            archived/legacy data, e.g. extracted from an old SEED volume with
+            `rdseed -p`, rather than fetched live from EarthScope:
+
+            ```python
+            >>> from pathlib import Path
+            >>> from pysmo import Response
+            >>> from pysmo.classes import SacPZ
+            >>> text = Path("SACPZ.IU.ANMO.00.BHZ").read_text()
+            >>> response = SacPZ.from_text(text)
+            >>> isinstance(response, Response)
+            True
+            >>> response.network, response.station
+            ('IU', 'ANMO')
+            >>>
+            ```
         """
         records = parse_sacpz(text)
         if len(records) != 1:
@@ -173,6 +191,14 @@ class SacPZ:
                 exactly one SAC PZ record.
             urllib3.exceptions.ResponseError: If the web service returns an
                 HTTP error.
+
+        Tip:
+            When fetching live from EarthScope rather than reading an
+            existing SAC PZ file, prefer
+            [`StationXML.fetch`][pysmo.classes.StationXML.fetch]: the
+            StationXML response also captures digital FIR/IIR stages, so it
+            always satisfies [`StagedResponse`][pysmo.StagedResponse], unlike
+            `SacPZ`.
 
         Examples:
             ```python

--- a/src/pysmo/conftest.py
+++ b/src/pysmo/conftest.py
@@ -53,12 +53,17 @@ def copy_testfiles(tmp_path: Path) -> Generator[None, Any, None]:
         Path(__file__).parent.parent.parent
         / "tests/lib/io/stationxml_example_single.xml"
     )
+    asset_sacpz = (
+        Path(__file__).parent.parent.parent / "tests/lib/io/sacpz_anmo_single.txt"
+    )
     test_testfile = Path(tmp_path) / "example.sac"
     test_iccsdir = Path(tmp_path) / "iccs-example/"
     test_stationxml = Path(tmp_path) / "stationxml_example_single.xml"
+    test_sacpz = Path(tmp_path) / "SACPZ.IU.ANMO.00.BHZ"
     copyfile(asset_testfile, test_testfile)
     copytree(asset_iccsdir, test_iccsdir)
     copyfile(asset_stationxml, test_stationxml)
+    copyfile(asset_sacpz, test_sacpz)
     try:
         os.chdir(tmp_path)
         yield

--- a/src/pysmo/lib/io/_sacpz.py
+++ b/src/pysmo/lib/io/_sacpz.py
@@ -40,6 +40,11 @@ _HEADER_PATTERN = re.compile(
 _REQUIRED_HEADERS = ("NETWORK", "STATION", "LOCATION", "CHANNEL", "START", "INPUT UNIT")
 
 
+def _parse_float(value: str) -> float:
+    """Convert `value` to `float`, tolerating Fortran `D`/`d` exponents."""
+    return float(value.replace("D", "E").replace("d", "e"))
+
+
 @dataclass
 class _RawSacPzResponse:
     """A single uninterpreted SAC PZ record."""
@@ -86,7 +91,7 @@ def _parse_complex_block(
     for _ in range(count):
         if index >= len(lines):
             raise ValueError(f"Unexpected end of text while parsing '{keyword}' block.")
-        real, imag = (float(part) for part in lines[index].split())
+        real, imag = (_parse_float(part) for part in lines[index].split())
         values.append(complex(real, imag))
         index += 1
     return values, index
@@ -166,7 +171,7 @@ def parse_sacpz(text: str) -> list[_RawSacPzResponse]:
             raise ValueError(
                 f"Expected 'CONSTANT' at line {index + 1}, found {constant_line!r}."
             )
-        overall_sensitivity = float(constant_line.split()[1])
+        overall_sensitivity = _parse_float(constant_line.split()[1])
         index += 1
 
         end_date_text = headers.get("END", "")
@@ -185,7 +190,9 @@ def parse_sacpz(text: str) -> list[_RawSacPzResponse]:
                 zeros=zeros,
                 overall_sensitivity=overall_sensitivity,
                 reference_sensitivity=(
-                    float(sensitivity_text.split()[0]) if sensitivity_text else None
+                    _parse_float(sensitivity_text.split()[0])
+                    if sensitivity_text
+                    else None
                 ),
                 input_units=headers["INPUT UNIT"],
             )

--- a/src/pysmo/tools/signal/__init__.py
+++ b/src/pysmo/tools/signal/__init__.py
@@ -2,23 +2,23 @@
 """
 Signal processing functions for pysmo types.
 
-Most functions in this module are convenience wrappers around
-[`scipy.signal`][] adapted to accept pysmo
-[`Seismogram`][pysmo.Seismogram] objects. This covers filtering
-([`bandpass`][pysmo.tools.signal.bandpass],
-[`lowpass`][pysmo.tools.signal.lowpass], etc.) and spectral analysis
-([`psd`][pysmo.tools.signal.psd], [`envelope`][pysmo.tools.signal.envelope]).
+Functions operate on pysmo [`Seismogram`][pysmo.Seismogram] objects and span
+filtering, spectral analysis, delay estimation and array-wide arrival-time
+refinement, instrument response removal, and frequency-domain calculus
+(integration and differentiation). Filters are additionally registered in a
+common registry, so they can be applied generically by name as well as by
+calling the specific filter function directly.
+
+Where a suitable implementation already exists in SciPy (e.g.
+[`scipy.signal`][]), functions in this module wrap it rather than
+reimplementing it; others implement seismology-specific algorithms with no
+direct SciPy equivalent.
 
 Functions that modify seismogram data follow the same `clone` convention as
 [`pysmo.functions`][]: without `clone` they operate in place
 and return `None`; with `clone=True` they return a modified copy.
 
-Specialised functions not found in SciPy include cross-correlation based
-delay estimation ([`delay`][pysmo.tools.signal.delay],
-[`multi_delay`][pysmo.tools.signal.multi_delay]) and the MCCC
-arrival-time solver ([`mccc`][pysmo.tools.signal.mccc]).
-
-!!! warning
+!!! note
 
     The [`Seismogram`][pysmo.Seismogram] type carries no unit label for
     `data`. Functions in this module do not track or convert physical

--- a/src/pysmo/tools/signal/_response.py
+++ b/src/pysmo/tools/signal/_response.py
@@ -102,11 +102,15 @@ def remove_response[T: Seismogram](
     [`Response.overall_sensitivity`][pysmo.Response.overall_sensitivity]).
 
     For a [`SacPZ`][pysmo.classes.SacPZ]-derived `response`, this path's output
-    is *not* in the units `input_units` declares: SAC PZ's `SENSITIVITY` header
-    (`reference_sensitivity`) stays in the sensor's native units (e.g. `M/S**2`
-    for an accelerometer), while SAC PZ's `poles`/`zeros`/`overall_sensitivity`
-    — and therefore `input_units`, and the full-deconvolution path below — are
-    normalised to displacement. A [`StationXML`][pysmo.classes.StationXML]-derived
+    is typically *not* in the units `input_units` declares: by SAC convention
+    (followed by e.g. the EarthScope SACPZ web service and `rdseed -p`), the
+    `SENSITIVITY` header (`reference_sensitivity`) stays in the sensor's
+    native units (e.g. `M/S**2` for an accelerometer), while
+    `poles`/`zeros`/`overall_sensitivity` — and therefore `input_units`, and
+    the full-deconvolution path below — are normalised to displacement. This
+    is a convention of the *producer*, not something `SacPZ`/`parse_sacpz`
+    enforce or verify — a hand-written SAC PZ file that doesn't follow it will
+    not exhibit this split. A [`StationXML`][pysmo.classes.StationXML]-derived
     `response` has no such split: both paths agree with `input_units`.
 
     **`pre_filt` given — spectral deconvolution.** Deconvolves `seismogram.data`

--- a/tests/lib/io/test_sacpz.py
+++ b/tests/lib/io/test_sacpz.py
@@ -67,6 +67,20 @@ class TestParseSacpz:
         records = parse_sacpz(MINIMAL_RECORD)
         assert records[0].reference_sensitivity is None
 
+    def test_fortran_d_exponent_tolerated(self) -> None:
+        """Hand-written SAC PZ text may use Fortran `D`/`d` exponents instead
+        of `E`/`e`, e.g. from older Fortran-heritage tooling."""
+        text = (
+            MINIMAL_RECORD.replace("e+00", "D+00")
+            .replace("e-02", "d-02")
+            .replace("1.0e+09", "1.0D+09")
+        )
+        records = parse_sacpz(text)
+        record = records[0]
+        assert record.poles == [complex(-1.0e-2, 0.0)]
+        assert record.zeros == [complex(0.0, 0.0), complex(0.0, 0.0)]
+        assert record.overall_sensitivity == pytest.approx(1.0e9)
+
     def test_two_concatenated_records(self) -> None:
         text = MINIMAL_RECORD + "\n\n" + MINIMAL_RECORD
         records = parse_sacpz(text)


### PR DESCRIPTION
Hand-written or legacy-tool-produced SAC PZ files (e.g. extracted from a SEED volume with rdseed -p) may use Fortran D/d scientific notation instead of E/e, which float() rejects. Also documents SacPZ.from_text with a disk-read example and adds a fetch() tip pointing to StationXML.fetch, which additionally captures digital stages.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--275.org.readthedocs.build/en/275/

<!-- readthedocs-preview pysmo end -->