### PR TITLE
docs(external-classes): add ObsPy Trace adapter recipe and protocol d…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ changelog: check-uv sync ## Generate CHANGELOG.md
 clean: ## Remove existing builds.
 	rm -rf build dist .egg pysmo.egg-info docs/build site
 
-docs: check-uv sync changelog ## Build html docs.
+docs: check-uv sync ## Build html docs.
 	uv run zensical build --clean
 
 format: check-uv ## Sort imports AND format code.

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -10,6 +10,7 @@ collect_ignore = [
     "snippets/division.py",
     "snippets/division_annotated.py",
     "snippets/duck.py",
+    "snippets/external_classes/trace_seismogram.py",
     "snippets/tutorial/season_detrend_v1.py",
     "snippets/tutorial/season_seismogram_short.py",
 ]

--- a/docs/snippets/external_classes/trace_seismogram.py
+++ b/docs/snippets/external_classes/trace_seismogram.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pandas as pd
+from obspy import Trace, UTCDateTime
+
+
+class TraceSeismogram:
+    def __init__(self, parent: Trace) -> None:
+        self._parent = parent
+
+    @property
+    def begin_time(self) -> pd.Timestamp:
+        return pd.Timestamp(self._parent.stats.starttime.ns, unit="ns", tz="UTC")
+
+    @begin_time.setter
+    def begin_time(self, value: pd.Timestamp) -> None:
+        self._parent.stats.starttime = UTCDateTime(ns=value.value)
+
+    @property
+    def delta(self) -> pd.Timedelta:
+        return pd.Timedelta(seconds=self._parent.stats.delta)
+
+    @delta.setter
+    def delta(self, value: pd.Timedelta) -> None:
+        self._parent.stats.delta = value.total_seconds()
+
+    @property
+    def data(self) -> np.ndarray:
+        return self._parent.data
+
+    @data.setter
+    def data(self, value: np.ndarray) -> None:
+        self._parent.data = value
+
+    @property
+    def end_time(self) -> pd.Timestamp:
+        if len(self.data) == 0:
+            return self.begin_time
+        return self.begin_time + self.delta * (len(self.data) - 1)

--- a/docs/usage/external-classes.md
+++ b/docs/usage/external-classes.md
@@ -161,7 +161,9 @@ class MyExtendedClass(ExternalClass):
         self.event_location = EventLocation(parent=self)
 ```
 
-## Example
+## Examples
+
+### `SAC`
 
 The pysmo package itself uses this pattern for the
 [`SAC`][pysmo.classes.SAC] class. The underlying
@@ -191,3 +193,186 @@ True
 ```
 
 For more details, see the [`SAC`][pysmo.classes.SAC] API documentation.
+
+### ObsPy's `Trace`
+
+The [`SAC`][pysmo.classes.SAC] example above is pysmo's own code adapting
+pysmo's own [`SacIO`][pysmo.lib.io.SacIO] class — useful to see the pattern
+used for real, but not literally an external class. A more realistic case
+for many seismologists: you already have waveform data as an
+[ObsPy](https://docs.obspy.org/) `Trace` object and want to run pysmo's
+functions and tools on it without converting your whole workflow.
+
+`Trace.stats` stores `starttime` as ObsPy's own `UTCDateTime` type (not
+[`pandas.Timestamp`][]) and `delta` as a plain `float` in seconds (not
+[`pandas.Timedelta`][]), so this needs the "attribute name and format
+differ" treatment from above, not the free out-of-the-box case: the adapter
+needs properties that convert between the two, not simple aliases.
+(`end_time` isn't read from `Trace.stats.endtime` at all — it's derived
+from `begin_time` and `delta` instead, the same way
+[`Seismogram`][pysmo.Seismogram]'s `end_time` is meant to be computed.)
+
+`Trace` is also mutable, in both directions. ObsPy's own processing methods
+(`.filter()`, `.taper()`, `.detrend()`, etc.) mutate it after you obtain it,
+and [`pysmo.functions`][] mutates it too, the other way round: functions
+like [`detrend`][pysmo.functions.detrend]/[`crop`][pysmo.functions.crop]/
+[`resample`][pysmo.functions.resample] assign to `.data`/`.delta`/
+`.begin_time` in place rather than returning a new object (unless called
+with `clone=True`). So both directions need to work, which means this
+adapter needs read/write properties with setters that write back to
+`self._parent`, matching [`SacSeismogram`][pysmo.classes.SacSeismogram]'s
+existing getter/setter pairs — not a read-only version.
+
+```python title="trace_seismogram.py"
+--8<-- "docs/snippets/external_classes/trace_seismogram.py"
+```
+
+<!-- skip: start -->
+
+```python
+>>> import numpy as np
+>>> from obspy import Trace
+>>> from pysmo import Seismogram
+>>> from pysmo.functions import detrend
+>>> trace = Trace(
+...     data=np.array([1.0, 2.0, 3.0, 2.0, 1.0]),
+...     header={
+...         "network": "XX",
+...         "station": "TEST",
+...         "location": "",
+...         "channel": "HHZ",
+...         "starttime": "2024-01-01T00:00:00",
+...         "delta": 0.01,
+...     },
+... )
+>>> trace_seis = TraceSeismogram(trace)
+>>> isinstance(trace_seis, Seismogram)
+True
+>>> detrend(trace_seis)
+>>> trace.data
+array([...])
+>>>
+```
+
+<!-- skip: end -->
+
+With the setters in place, every [`pysmo.functions`][] and
+[`pysmo.tools`][] call that takes a [`Seismogram`][pysmo.Seismogram] works
+on `trace_seis` directly — including the ones that mutate in place, like
+`detrend` above. Note what this adapter does *not* attempt: `Trace.stats`
+has no latitude/longitude — that lives in ObsPy's separate `Inventory`
+hierarchy, not on `Trace` itself — so `TraceSeismogram` only ever satisfies
+[`Seismogram`][pysmo.Seismogram], never [`Station`][pysmo.Station]. Supply
+station/event metadata separately, the same way
+[`GeoCsvSeismogram.fetch()`][pysmo.classes.GeoCsvSeismogram.fetch] does.
+
+!!! tip
+
+    Notice `detrend` is available in two different shapes above: ObsPy
+    exposes it as a method on `Trace` (`trace.detrend(...)`), while pysmo
+    exposes the same operation as a standalone function that takes a
+    [`Seismogram`][pysmo.Seismogram] (`detrend(seismogram)`). That
+    difference isn't incidental. A method bound to `Trace` only ever works
+    on a `Trace` (or a subclass of it). A function written against the
+    [`Seismogram`][pysmo.Seismogram] protocol works on anything that
+    satisfies it — `TraceSeismogram` here,
+    [`SacSeismogram`][pysmo.classes.SacSeismogram], a
+    [mini class](mini-classes.md), or any bespoke class you write yourself.
+    That's why the exact same [`detrend`][pysmo.functions.detrend] call
+    works unchanged on the [`SAC`][pysmo.classes.SAC] example above and on
+    `trace_seis` here, with no dispatch logic anywhere to make that happen.
+    Targeting the protocol rather than one specific class is what makes
+    every function in [`pysmo.functions`][]/[`pysmo.tools`][] reusable this
+    way. And it isn't limited to pysmo's own functions — any function you
+    write yourself against [`Seismogram`][pysmo.Seismogram] gets the same
+    property for free.
+
+## Beyond adapting existing classes
+
+Everything above is about making an external class usable with pysmo's
+*existing* functions, in Python. That's useful, but it undersells what a
+pysmo type actually is.
+
+You've already built this twice in this chapter, in two different shapes,
+without necessarily naming what it was. The helper-class approach builds a
+narrow view as a separate object that reads from — and writes back to — a
+richer parent; [`SacSeismogram`][pysmo.classes.SacSeismogram] is a real
+example of exactly this: [`SAC`][pysmo.classes.SAC] carries the full
+complexity of a SAC file's header, [`SacSeismogram`][pysmo.classes.SacSeismogram]
+exposes only what [`Seismogram`][pysmo.Seismogram] needs. The thin-subclass
+approach doesn't even need a separate object: a single bespoke class can
+carry its own extra attributes directly, alongside the ones a protocol
+requires, and still be handed to any function expecting that protocol
+unchanged. Either way, the "rich" and "narrow" views aren't two objects with
+data copied between them — they're two readings of the same one.
+
+That's actually a general pattern, not something specific to these two
+examples. The same object can be two different things at once, depending on
+who's looking at it. To the code that owns it, a seismogram can carry
+arbitrarily rich, problem-specific state — processing history, quality
+flags, picks, provenance, whatever the task at hand actually needs. To a
+function written against [`Seismogram`][pysmo.Seismogram], that same object
+is just `begin_time`, `data`, `delta`, nothing more. Both are true at the
+same time, of the same instance — the type doesn't strip anything away, it
+just describes which part of the object a given piece of code has committed
+to relying on.
+
+The narrow view is the more interesting half of that pair. A type like
+[`Seismogram`][pysmo.Seismogram] isn't really a Python feature — it's a
+minimal specification of what a seismogram fundamentally needs to be,
+arrived at by asking what processing functions actually require rather than
+what any one class happens to expose (see
+[What should become a type?](types.md#what-should-become-a-type)).
+[`Protocol`][typing.Protocol] is simply the notation this specification
+happens to be written in today. The definition itself — begin time, data,
+sampling interval, nothing more — would translate just as directly into a
+struct in C or Fortran, a database schema, or a paragraph of prose. It
+doesn't depend on Python, or on pysmo, to remain true.
+
+That distinction matters over a project's lifetime. Libraries and file
+formats change — sometimes for good reasons, sometimes just because tooling
+fashions shift — and code written directly against one specific class
+inherits that churn. Code written against a well-considered, minimal
+interface mostly doesn't: only the adaptation layer at the boundary needs to
+change, not the logic behind it. The same holds on a smaller scale too —
+say you move a slow step like [`mccc`][pysmo.tools.signal.mccc] from Python
+to a compiled language for speed. The hard part of a move like that is
+never translating syntax — it's figuring out what the actual minimal data
+model needs to be. If that work is already done, captured as a small,
+deliberate interface rather than smeared across whatever attributes a
+particular class happened to expose, the move means reimplementing the
+interface and its adapters in the new language's idiom, not re-deriving the
+whole data model from scratch.
+
+It isn't only external change that's unpredictable, either. You rarely know
+in advance how complex the class supporting a particular problem will need
+to become. A bespoke class doesn't have to mean a dataclass with a few extra
+attributes — that's the simplest case, not the only one. What starts that
+way can, as a project's real requirements surface, turn into something far
+more involved. [AIMBAT](https://github.com/pysmo/aimbat) — an arrival-time
+picking package built on pysmo — shows both ends of that range. Its first
+version had nowhere else to put processing state, so it stored things like
+filter parameters directly in SAC's generic
+`user6`/`user7`/`kuser1`/`kuser2` header fields — fields with no defined
+meaning of their own, repurposed because nothing better was available.
+(It's also why old AIMBAT-processed SAC files can have oddly-populated
+header fields that are confusing to decode later, if you ever come across
+one.) Current AIMBAT solves the same problem properly instead: its
+seismogram objects are backed by a SQL database, with `begin_time` and
+`delta` stored as ordinary table columns and `data` fetched from a separate
+table only when it's actually needed. That split pays off in a very
+concrete way too: changing a pick or a sampling interval is a small
+database update, not a read of the whole waveform file. Do the same thing
+with a SAC file being read directly, and there's no such distinction
+available — updating one value means touching the entire seismogram. None
+of that is something you can plan for up front, and it doesn't need to be.
+The protocol boundary doesn't ask the rich side to stay simple, or to stay
+anything in particular — only that
+[`begin_time`][pysmo.Seismogram.begin_time],
+[`data`][pysmo.Seismogram.data], and
+[`delta`][pysmo.Seismogram.delta] keep meaning what they always meant. The
+processing logic on the other side of that boundary never has to change, no
+matter how unrecognisable the rich side becomes.
+
+Pysmo's types are one attempt at doing this work for seismology. The same
+exercise is worth doing for whatever is specific to your own project.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,12 @@ namespace_packages = true
 disallow_untyped_defs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-exclude = ['division\.py$', 'division_annotated\.py$', 'duck\.py$']
+exclude = [
+  'division\.py$',
+  'division_annotated\.py$',
+  'duck\.py$',
+  'docs/snippets/external_classes/trace_seismogram\.py$',
+]
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/tests/docs/test_obspy_trace_recipe.py
+++ b/tests/docs/test_obspy_trace_recipe.py
@@ -1,0 +1,63 @@
+"""Verifies the `TraceSeismogram` recipe in `docs/usage/external-classes.md`.
+
+Skipped unless `obspy` is installed, since pysmo does not (and should not)
+depend on ObsPy — this recipe only demonstrates interoperability for users
+who already have it. Not run in normal CI. Given a bug report against a
+specific ObsPy version, install that version and run this test directly,
+e.g.:
+
+    uv run --with obspy pytest tests/docs/test_obspy_trace_recipe.py
+
+The `TraceSeismogram` class lives in
+`docs/snippets/external_classes/trace_seismogram.py` and is loaded from
+there (rather than duplicated here) so the tested code and the documented
+code can never drift apart.
+"""
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+obspy = pytest.importorskip("obspy")
+
+from pysmo import Seismogram  # noqa: E402
+from pysmo.functions import detrend  # noqa: E402
+
+SNIPPET_PATH = (
+    Path(__file__).parents[2] / "docs/snippets/external_classes/trace_seismogram.py"
+)
+
+
+def _load_trace_seismogram_class() -> Any:
+    assert SNIPPET_PATH.is_file(), f"snippet not found: {SNIPPET_PATH}"
+    spec = importlib.util.spec_from_file_location("trace_seismogram", SNIPPET_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.TraceSeismogram
+
+
+def test_trace_seismogram_recipe() -> None:
+    TraceSeismogram = _load_trace_seismogram_class()
+
+    trace = obspy.Trace(
+        data=np.array([1.0, 2.0, 3.0, 2.0, 1.0]),
+        header={
+            "network": "XX",
+            "station": "TEST",
+            "location": "",
+            "channel": "HHZ",
+            "starttime": "2024-01-01T00:00:00",
+            "delta": 0.01,
+        },
+    )
+    trace_seis = TraceSeismogram(trace)
+
+    assert isinstance(trace_seis, Seismogram)
+
+    original_data = trace.data.copy()
+    detrend(trace_seis)
+    assert not np.array_equal(trace.data, original_data)


### PR DESCRIPTION
…iscussion

Splits the closing "Example" section into SAC (pysmo's own code) and a genuinely external ObsPy Trace adapter recipe, verified against a real obspy install via a new pytest.importorskip-guarded test that imports the same snippet the docs include. Adds a closing "Beyond adapting existing classes" section on protocol types as portable specifications, illustrated with AIMBAT v1's SAC-header misuse and AIMBAT v2's database-backed design.

Also decouples changelog generation from `make docs`, since the GitHub Actions workflow now owns CHANGELOG.md.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--280.org.readthedocs.build/en/280/

<!-- readthedocs-preview pysmo end -->