### PR TITLE
refactor(types): unexport and privatise EpochProvenance

### DIFF
--- a/src/pysmo/__init__.py
+++ b/src/pysmo/__init__.py
@@ -22,7 +22,6 @@ subpackages.
 from importlib.metadata import version
 
 from ._types import (
-    EpochProvenance,
     Event,
     Location,
     LocationWithDepth,
@@ -75,7 +74,6 @@ __all__ = [
     "Response",
     "StagedResponse",
     "ResponseStage",
-    "EpochProvenance",
     "MiniSeismogram",
     "MiniStation",
     "MiniEvent",

--- a/src/pysmo/_types/response.py
+++ b/src/pysmo/_types/response.py
@@ -13,7 +13,6 @@ __all__ = [
     "StagedResponse",
     "MiniResponseStage",
     "MiniStagedResponse",
-    "EpochProvenance",
 ]
 
 
@@ -137,13 +136,20 @@ class StagedResponse(Response, Protocol):
 
 
 @runtime_checkable
-class EpochProvenance(Protocol):
-    """Protocol class to define the `EpochProvenance` type.
+class _EpochProvenance(Protocol):
+    """Protocol class to define the `_EpochProvenance` type.
 
     Channel identity (network/station/location/channel) plus the validity
     window of one response epoch — the bookkeeping needed to place a
     `Response` within a specific channel and time range, independent of the
     response data itself.
+
+    Private: unlike `Response`/`ResponseStage`/`StagedResponse`, this exists
+    only so `pysmo.lib.io.write_sacpz` (via `ResponseWithEpoch`) can
+    type-check, not to be implemented by third-party code directly. Real
+    callers already satisfy it structurally as part of a bigger object
+    (`SacPZ`, `StationXML`), so it is deliberately not exported at the
+    `pysmo` root namespace.
     """
 
     network: str

--- a/src/pysmo/lib/io/_sacpz.py
+++ b/src/pysmo/lib/io/_sacpz.py
@@ -31,23 +31,23 @@ from typing import Protocol, runtime_checkable
 
 import pandas as pd
 
-from pysmo import EpochProvenance, Response
+from pysmo import Response
+from pysmo._types.response import _EpochProvenance
 from pysmo.lib.validators import convert_to_utc_timestamp
 
 __all__ = ["parse_sacpz", "write_sacpz", "ResponseWithEpoch"]
 
 
 @runtime_checkable
-class ResponseWithEpoch(Response, EpochProvenance, Protocol):
+class ResponseWithEpoch(Response, _EpochProvenance, Protocol):
     """Protocol class to define the `ResponseWithEpoch` type.
 
-    A [`Response`][pysmo.Response] with
-    [`EpochProvenance`][pysmo.EpochProvenance] — what
-    [`write_sacpz`][pysmo.lib.io.write_sacpz] requires. Any object
-    satisfying both protocols (e.g. [`SacPZ`][pysmo.classes.SacPZ] or
-    [`StationXML`][pysmo.classes.StationXML]) already satisfies this one
-    structurally; there is usually no need to reference it directly unless
-    type-annotating a variable meant to hold whatever `write_sacpz` accepts.
+    A [`Response`][pysmo.Response] with `_EpochProvenance` (channel identity plus a
+    validity window) — what [`write_sacpz`][pysmo.lib.io.write_sacpz] requires. Any
+    object satisfying both protocols (e.g. [`SacPZ`][pysmo.classes.SacPZ] or
+    [`StationXML`][pysmo.classes.StationXML]) already satisfies this one structurally;
+    there is usually no need to reference it directly unless type-annotating a variable
+    meant to hold whatever `write_sacpz` accepts.
     """
 
 
@@ -221,7 +221,7 @@ def parse_sacpz(text: str) -> list[_RawSacPzResponse]:
 
 
 def _sacpz_block(response: ResponseWithEpoch) -> str:
-    """Render a single Response+EpochProvenance object as one SAC PZ record."""
+    """Render a single `ResponseWithEpoch` object as one SAC PZ record."""
     end_date = response.end_date.isoformat() if response.end_date is not None else ""
 
     lines = [
@@ -256,9 +256,8 @@ def write_sacpz(
     """Write one or more Response objects to a SAC PZ file.
 
     Args:
-        responses: A single object satisfying both
-            [`Response`][pysmo.Response] and
-            [`EpochProvenance`][pysmo.EpochProvenance] (e.g.
+        responses: A single object satisfying
+            [`ResponseWithEpoch`][pysmo.lib.io.ResponseWithEpoch] (e.g.
             [`SacPZ`][pysmo.classes.SacPZ] or
             [`StationXML`][pysmo.classes.StationXML]), or a non-empty
             sequence of them.


### PR DESCRIPTION
Rename to _EpochProvenance and drop it from pysmo.__all__: it exists solely so write_sacpz can type-check via ResponseWithEpoch, never as a type third-party code implements or annotates directly. Not part of any release yet, so no real breakage.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--283.org.readthedocs.build/en/283/

<!-- readthedocs-preview pysmo end -->