### PR TITLE
fix(tools-signal): honour max_shift in multi_delay and ICCS

### DIFF
--- a/src/pysmo/tools/iccs/_iccs.py
+++ b/src/pysmo/tools/iccs/_iccs.py
@@ -622,7 +622,7 @@ class ICCS:
         convergence_limit: float = IccsDefaults.convergence_limit,
         convergence_method: ConvergenceMethod = IccsDefaults.convergence_method,
         max_iter: int = IccsDefaults.max_iter,
-        max_shift: pd.Timedelta | None = None,
+        max_shift: NonNegativeTimedelta | None = None,
     ) -> IccsResult:
         """Run the ICCS algorithm.
 
@@ -632,7 +632,10 @@ class ICCS:
             convergence_limit: Convergence limit at which the algorithm stops.
             convergence_method: Method to calculate convergence criterion.
             max_iter: Maximum number of iterations.
-            max_shift: Maximum (absolute) shift to consider (see [`delay()`][pysmo.tools.signal.delay]).
+            max_shift: Maximum (absolute) shift to consider in each iteration,
+                relative to the stack at that iteration (see
+                [`delay()`][pysmo.tools.signal.delay]). This is not a bound on
+                the cumulative shift over the full run.
 
         Returns:
             An [`IccsResult`][pysmo.tools.iccs.IccsResult] containing the
@@ -645,7 +648,12 @@ class ICCS:
             prev_stack = clone_to_mini(MiniSeismogram, self.stack)
 
             # Get delays and correlation coefficients for all seismograms in one go
-            delays, ccs = multi_delay(self.stack, self.cc_seismograms, abs_max=autoflip)
+            delays, ccs = multi_delay(
+                self.stack,
+                self.cc_seismograms,
+                abs_max=autoflip,
+                max_shift=max_shift,
+            )
 
             # Update seismograms based on results and settings.
             for delay, cc, cc_seismogram in zip(delays, ccs, self.cc_seismograms):

--- a/src/pysmo/tools/signal/_delay.py
+++ b/src/pysmo/tools/signal/_delay.py
@@ -11,6 +11,7 @@ from scipy.signal import correlate as _correlate
 from scipy.stats.mstats import pearsonr as _pearsonr
 
 from pysmo import Seismogram
+from pysmo.typing import NonNegativeTimedelta
 
 __all__ = ["delay", "multi_delay", "multi_multi_delay", "mccc"]
 
@@ -31,7 +32,7 @@ def delay(
     seismogram1: Seismogram,
     seismogram2: Seismogram,
     total_delay: bool = False,
-    max_shift: pd.Timedelta | None = None,
+    max_shift: NonNegativeTimedelta | None = None,
     abs_max: bool = False,
 ) -> tuple[pd.Timedelta, float]:
     """Cross correlates two seismograms to determine signal delay.
@@ -222,7 +223,10 @@ def delay(
 
 
 def multi_delay(
-    template: Seismogram, seismograms: Sequence[Seismogram], abs_max: bool = False
+    template: Seismogram,
+    seismograms: Sequence[Seismogram],
+    abs_max: bool = False,
+    max_shift: NonNegativeTimedelta | None = None,
 ) -> tuple[list[pd.Timedelta], list[float]]:
     """Calculates delays and correlation coefficients for a list of seismograms against a template.
 
@@ -235,6 +239,10 @@ def multi_delay(
         template: Template seismogram object.
         seismograms: Sequence of Seismogram objects.
         abs_max: If `True`, uses absolute max correlation (polarity insensitive).
+        max_shift: Maximum (absolute) shift to consider. If set, the search for
+            the maximum correlation is restricted to lags within `max_shift` of
+            zero, which can avoid spuriously large delays when the correlation
+            has multiple peaks (e.g. from a cyclic waveform).
 
     Returns:
         delays: Delays of each input seismogram relative to template.
@@ -242,6 +250,16 @@ def multi_delay(
 
     Raises:
         ValueError: If any seismogram has a different sampling rate than the template.
+        ValueError: If `max_shift` is negative.
+
+    Note:
+        Unlike [`delay`][pysmo.tools.signal.delay], `max_shift` here does not
+        require the seismograms to be of equal length, and does not speed up
+        the calculation (the full cross-correlation is always computed; only
+        the search for its maximum is restricted). If the true delay lies
+        outside the `max_shift` range, the delay returned will be constrained
+        to (and typically found at the edge of) that range, and its
+        correlation coefficient will usually be low.
 
     Note:
         Seismograms with zero standard deviation (i.e. constant data) cannot be
@@ -285,7 +303,24 @@ def multi_delay(
         True
         >>>
         ```
+
+        Use `max_shift` to restrict the search space, e.g. to avoid a spurious
+        match at a larger, unwanted lag:
+
+        ```python
+        >>> import pandas as pd
+        >>> shifted = MiniSeismogram(data=np.roll(data, 10))
+        >>> delays, ccs = multi_delay(
+        ...     template, [shifted], max_shift=pd.Timedelta(seconds=20)
+        ... )
+        >>> delays[0].total_seconds()
+        10.0
+        >>>
+        ```
     """
+    if max_shift is not None and max_shift < pd.Timedelta(0):
+        raise ValueError("max_shift must not be negative.")
+
     if not seismograms:
         return [], []
 
@@ -341,14 +376,21 @@ def multi_delay(
     # inverse FFT & scale (div by len(template) for Pearson approx)
     cc_matrix = irfft(cc_freq, n=n_fft, axis=1) / len_t
 
-    # find maxima
-    if abs_max:
-        max_indices = np.argmax(np.abs(cc_matrix), axis=1)
-    else:
-        max_indices = np.argmax(cc_matrix, axis=1)
+    # find maxima, restricting the search to within max_shift if set
+    mid_point = n_fft // 2
+    search_matrix = np.abs(cc_matrix) if abs_max else cc_matrix
+    if max_shift is not None:
+        max_lag_in_samples = math.ceil(max_shift / template.delta)
+        index_lags = np.where(
+            np.arange(n_fft) <= mid_point,
+            np.arange(n_fft),
+            np.arange(n_fft) - n_fft,
+        )
+        search_matrix = search_matrix.copy()
+        search_matrix[:, np.abs(index_lags) > max_lag_in_samples] = -np.inf
+    max_indices = np.argmax(search_matrix, axis=1)
 
     # convert circular indices to signed lags
-    mid_point = n_fft // 2
     signed_lags = np.where(max_indices <= mid_point, max_indices, max_indices - n_fft)
     delta = template.delta
     delays = [int(lag) * delta for lag in signed_lags]

--- a/tests/tools/iccs/test_iccs.py
+++ b/tests/tools/iccs/test_iccs.py
@@ -173,6 +173,28 @@ class TestICCSUpdateWarning:
 class TestICCSParameters(TestICCSBase):
     """Test changing parameters and methods (other than __call__)."""
 
+    def test_call_forwards_max_shift(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`ICCS.__call__` must forward `max_shift` to `multi_delay` on every
+        iteration; it must not be silently dropped."""
+        from pysmo.tools.iccs import _iccs as iccs_module
+
+        original_multi_delay = iccs_module.multi_delay
+        seen_max_shifts: list[pd.Timedelta | None] = []
+
+        def spy_multi_delay(
+            *args: object, **kwargs: object
+        ) -> tuple[list[pd.Timedelta], list[float]]:
+            seen_max_shifts.append(kwargs.get("max_shift"))  # type: ignore[arg-type]
+            return original_multi_delay(*args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(iccs_module, "multi_delay", spy_multi_delay)
+
+        max_shift = pd.Timedelta(seconds=3)
+        self.iccs(max_iter=2, max_shift=max_shift)
+
+        assert len(seen_max_shifts) >= 1
+        assert all(seen == max_shift for seen in seen_max_shifts)
+
     def test_change_timewindow(self) -> None:
         assert self.iccs.window_pre.total_seconds() == -15
         with pytest.raises(ValueError):

--- a/tests/tools/signal/test_delay.py
+++ b/tests/tools/signal/test_delay.py
@@ -213,6 +213,92 @@ def test_multi_delay_abs_max() -> None:
     assert ccs[0] < 0
 
 
+def test_multi_delay_max_shift_recovers_known_shift() -> None:
+    """
+    Test `multi_delay` with `max_shift` set wide enough to include the true shift.
+
+    Verifies that restricting the search space via `max_shift` still recovers
+    the correct delay when the true shift lies within the restricted range.
+    """
+    data = np.sin(np.linspace(0, 8 * np.pi, 1000))
+    template = MiniSeismogram(data=data.copy())
+    nroll = 10
+    seis = MiniSeismogram(data=np.roll(data, nroll))
+    delays, ccs = multi_delay(template, [seis], max_shift=pd.Timedelta(seconds=20))
+    expected_delay = nroll * template.delta
+    assert delays[0] == expected_delay
+    assert ccs[0] == pytest.approx(1, abs=0.05)
+
+
+def test_multi_delay_max_shift_restricts_search() -> None:
+    """
+    Test that `multi_delay` confines the correlation search to `max_shift`.
+
+    Verifies that when `max_shift` is set narrower than the true signal shift,
+    the returned delay is bounded by `max_shift` rather than the (unreachable)
+    true shift, confirming the search space is actually restricted rather than
+    the parameter being silently ignored.
+    """
+    data = np.sin(np.linspace(0, 8 * np.pi, 1000))
+    template = MiniSeismogram(data=data.copy())
+    nroll = 50
+    seis = MiniSeismogram(data=np.roll(data, nroll))
+
+    max_shift = pd.Timedelta(seconds=10)
+    delays, _ = multi_delay(template, [seis], max_shift=max_shift)
+
+    # For this sinusoid, correlation increases monotonically towards the
+    # (excluded) true peak at nroll within this window, so the masked search
+    # lands exactly on the edge. This exact value is specific to this
+    # waveform/nroll/max_shift combination; if you change any of them,
+    # re-derive the expected delay rather than assuming it still holds.
+    assert delays[0] == max_shift
+
+
+def test_multi_delay_max_shift_with_abs_max() -> None:
+    """
+    Test `max_shift` combined with `abs_max` (polarity-insensitive matching).
+
+    Verifies that the absolute-value masking used for `abs_max=True` respects
+    `max_shift` correctly, both when the true (anti-correlated) shift lies
+    within the restricted range and when it lies outside it.
+    """
+    data = np.sin(np.linspace(0, 8 * np.pi, 1000))
+    template = MiniSeismogram(data=data.copy())
+
+    nroll = 12
+    seis = MiniSeismogram(data=-np.roll(data, nroll))
+    delays, ccs = multi_delay(
+        template, [seis], abs_max=True, max_shift=pd.Timedelta(seconds=20)
+    )
+    assert delays[0] == nroll * template.delta
+    assert ccs[0] < 0
+
+    nroll_far = 50
+    seis_far = MiniSeismogram(data=-np.roll(data, nroll_far))
+    max_shift = pd.Timedelta(seconds=10)
+    delays_far, ccs_far = multi_delay(
+        template, [seis_far], abs_max=True, max_shift=max_shift
+    )
+    assert delays_far[0] == max_shift
+    assert ccs_far[0] < 0
+
+
+def test_multi_delay_negative_max_shift_raises() -> None:
+    """
+    Test that `multi_delay` raises `ValueError` for a negative `max_shift`.
+
+    `#!py delay(seismogram1, seismogram2, max_shift=...)` also rejects a
+    negative `max_shift`, though only incidentally (`numpy.pad` raises on a
+    negative pad width). `multi_delay` checks explicitly instead, since its
+    FFT-based search has no equivalent implicit failure mode.
+    """
+    template = MiniSeismogram(data=np.array([1.0, 2.0, 3.0]))
+    seis = MiniSeismogram(data=np.array([1.0, 2.0, 3.0]))
+    with pytest.raises(ValueError):
+        multi_delay(template, [seis], max_shift=pd.Timedelta(seconds=-1))
+
+
 def test_multi_delay_different_delta_raises() -> None:
     """
     Test that `multi_delay` raises `ValueError` for mismatched sampling rates.


### PR DESCRIPTION
ICCS.__call__() accepted max_shift but silently dropped it after the switch to multi_delay() in #249, since multi_delay() never supported it. multi_delay() now masks the FFT lag search to max_shift, wired through from ICCS.__call__() (documented as per-iteration, not cumulative). max_shift is typed NonNegativeTimedelta throughout, since 0 is a valid (if degenerate) value.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--289.org.readthedocs.build/en/289/

<!-- readthedocs-preview pysmo end -->