### PR TITLE
refactor(io): delegate http_get retry policy to urllib3.util.Retry

### DIFF
--- a/src/pysmo/lib/io/_http.py
+++ b/src/pysmo/lib/io/_http.py
@@ -1,10 +1,9 @@
 """Shared HTTP helper for pysmo web-service requests."""
 
-import random
-import time
 from typing import Any
 
 import urllib3
+from urllib3.util.retry import Retry
 
 __all__ = [
     "http_get",
@@ -29,11 +28,6 @@ _MAX_BACKOFF_SECONDS = 120
 _pool = urllib3.PoolManager()
 
 
-def _sleep_with_backoff(base_delay_seconds: int | float, attempt: int) -> None:
-    delay = min(base_delay_seconds * (2**attempt), _MAX_BACKOFF_SECONDS)
-    time.sleep(random.uniform(0, delay))
-
-
 def http_get(
     url: str,
     fields: dict[str, Any],
@@ -46,17 +40,20 @@ def http_get(
     """Perform an HTTP GET request, retrying transient failures.
 
     Connection failures, timeouts, and responses with a transient status
-    (429, 500, 502, 503, or 504) are retried up to `request_retries` times,
-    with exponential backoff and jitter between attempts using
-    `retry_delay_seconds` as the base delay. Any other HTTP error status
-    raises immediately.
+    (429, 500, 502, 503, or 504) are retried up to `request_retries` times.
+    The first retry is immediate; retry `n` thereafter waits
+    `retry_delay_seconds * 2 ** (n - 1)` seconds plus a random jitter of up
+    to `retry_delay_seconds`, capped at 120 seconds total. A `Retry-After`
+    header on a 429 or 503 response replaces that wait, clamped to 6 hours.
+    Any other HTTP error status raises immediately.
 
     Args:
         url: URL to request.
         fields: Query parameters to send with the request.
         timeout_seconds: Timeout in seconds for each request attempt.
         request_retries: Maximum number of request attempts (must be at least 1).
-        retry_delay_seconds: Base delay in seconds between retries.
+        retry_delay_seconds: Base delay for the backoff schedule, and the
+            width of the random jitter added to each wait.
         redirect: Whether to automatically follow HTTP redirects.
 
     Returns:
@@ -73,28 +70,25 @@ def http_get(
     if request_retries < 1:
         raise ValueError("request_retries must be at least 1.")
 
-    attempt = 0
-    while True:
-        last_attempt = attempt >= request_retries - 1
-        try:
-            response = _pool.request(
-                "GET",
-                url,
-                fields=fields,
-                timeout=timeout_seconds,
-                redirect=redirect,
-            )
-        except urllib3.exceptions.HTTPError:
-            if last_attempt:
-                raise
-            _sleep_with_backoff(retry_delay_seconds, attempt)
-            attempt += 1
-            continue
-
-        if response.status in _RETRYABLE_STATUSES and not last_attempt:
-            _sleep_with_backoff(retry_delay_seconds, attempt)
-            attempt += 1
-            continue
-        if response.status >= 400:
-            raise urllib3.exceptions.ResponseError(f"HTTP {response.status}")
-        return response.data
+    # raise_on_status=False: hand the exhausted response back so the status
+    # check below raises a consistent ResponseError for any error status.
+    retries = Retry(
+        total=request_retries - 1,
+        status_forcelist=_RETRYABLE_STATUSES,
+        backoff_factor=retry_delay_seconds,
+        backoff_max=_MAX_BACKOFF_SECONDS,
+        backoff_jitter=retry_delay_seconds,
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    response = _pool.request(
+        "GET",
+        url,
+        fields=fields,
+        timeout=timeout_seconds,
+        redirect=redirect,
+        retries=retries,
+    )
+    if response.status >= 400:
+        raise urllib3.exceptions.ResponseError(f"HTTP {response.status}")
+    return response.data

--- a/tests/lib/io/test_http.py
+++ b/tests/lib/io/test_http.py
@@ -1,11 +1,14 @@
 """Tests for pysmo.lib.io._http."""
 
-from collections.abc import Iterator, Sequence
+import threading
+import time
+from collections.abc import Callable, Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 import urllib3
+from urllib3.util.retry import Retry
 
 import pysmo.lib.io._http as http_mod
 
@@ -16,43 +19,37 @@ class FakeResponse:
         self.data = data
 
 
-class MultiResponse:
-    """Returns a sequence of canned responses/exceptions on successive `request` calls."""
+class CapturingPool:
+    """Records the arguments of each `request` call and returns a canned response."""
 
-    def __init__(self, responses: Sequence[FakeResponse | Exception]) -> None:
-        self._iter: Iterator[FakeResponse | Exception] = iter(responses)
+    def __init__(self, response: FakeResponse) -> None:
+        self.response = response
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
 
     def request(self, method: str, url: str, **kwargs: Any) -> FakeResponse:
         self.calls.append((method, url, kwargs))
-        result = next(self._iter)
-        if isinstance(result, Exception):
-            raise result
-        return result
+        return self.response
 
 
-@pytest.fixture(autouse=True)
-def patch_pool(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-    """Replace the module-level pool with a `MagicMock` so no test hits the network.
+@pytest.fixture
+def capturing_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[FakeResponse], CapturingPool]:
+    def _install(response: FakeResponse) -> CapturingPool:
+        pool = CapturingPool(response)
+        monkeypatch.setattr(http_mod, "_pool", pool)
+        return pool
 
-    Tests that need canned responses replace this again via `make_pool`.
-    """
-    pool = MagicMock()
-    monkeypatch.setattr(http_mod, "_pool", pool)
-    return pool
-
-
-def make_pool(
-    responses: Sequence[FakeResponse | Exception], monkeypatch: pytest.MonkeyPatch
-) -> MultiResponse:
-    multi = MultiResponse(responses)
-    monkeypatch.setattr(http_mod, "_pool", multi)
-    return multi
+    return _install
 
 
-class TestHttpGet:
-    def test_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        pool = make_pool([FakeResponse(200, b"ok")], monkeypatch)
+class TestWrapperBehaviour:
+    """Behaviour owned by `http_get` itself, independent of urllib3's retrying."""
+
+    def test_success_returns_body(
+        self, capturing_pool: Callable[[FakeResponse], CapturingPool]
+    ) -> None:
+        pool = capturing_pool(FakeResponse(200, b"ok"))
         result = http_mod.http_get(
             "http://example.com",
             {"key": "val"},
@@ -61,15 +58,17 @@ class TestHttpGet:
             retry_delay_seconds=0,
         )
         assert result == b"ok"
-        assert len(pool.calls) == 1
         method, url, kwargs = pool.calls[0]
         assert method == "GET"
         assert url == "http://example.com"
         assert kwargs["fields"] == {"key": "val"}
         assert kwargs["timeout"] == 5
+        assert kwargs["redirect"] is True
 
-    def test_4xx_raises_immediately(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        make_pool([FakeResponse(404)], monkeypatch)
+    def test_non_retryable_status_raises(
+        self, capturing_pool: Callable[[FakeResponse], CapturingPool]
+    ) -> None:
+        capturing_pool(FakeResponse(404))
         with pytest.raises(urllib3.exceptions.ResponseError, match="HTTP 404"):
             http_mod.http_get(
                 "http://example.com",
@@ -79,23 +78,13 @@ class TestHttpGet:
                 retry_delay_seconds=0,
             )
 
-    def test_500_then_200_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        pool = make_pool(
-            [FakeResponse(500), FakeResponse(200, b"recovered")], monkeypatch
-        )
-        result = http_mod.http_get(
-            "http://example.com",
-            {},
-            timeout_seconds=5,
-            request_retries=3,
-            retry_delay_seconds=0,
-        )
-        assert result == b"recovered"
-        assert len(pool.calls) == 2
-
-    def test_500_exhausts_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        pool = make_pool([FakeResponse(500)] * 3, monkeypatch)
-        with pytest.raises(urllib3.exceptions.ResponseError, match="HTTP 500"):
+    def test_exhausted_retryable_status_raises(
+        self, capturing_pool: Callable[[FakeResponse], CapturingPool]
+    ) -> None:
+        # With raise_on_status=False, urllib3 hands back the final 503 and
+        # http_get is responsible for turning it into an error.
+        capturing_pool(FakeResponse(503))
+        with pytest.raises(urllib3.exceptions.ResponseError, match="HTTP 503"):
             http_mod.http_get(
                 "http://example.com",
                 {},
@@ -103,7 +92,6 @@ class TestHttpGet:
                 request_retries=3,
                 retry_delay_seconds=0,
             )
-        assert len(pool.calls) == 3
 
     def test_zero_retries_raises(self) -> None:
         with pytest.raises(ValueError, match="request_retries must be at least 1"):
@@ -115,61 +103,10 @@ class TestHttpGet:
                 retry_delay_seconds=0,
             )
 
-    @pytest.mark.parametrize("status", [429, 502, 503, 504])
-    def test_transient_status_then_200_retries(
-        self, status: int, monkeypatch: pytest.MonkeyPatch
+    def test_retry_policy_configuration(
+        self, capturing_pool: Callable[[FakeResponse], CapturingPool]
     ) -> None:
-        pool = make_pool(
-            [FakeResponse(status), FakeResponse(200, b"recovered")], monkeypatch
-        )
-        result = http_mod.http_get(
-            "http://example.com",
-            {},
-            timeout_seconds=5,
-            request_retries=3,
-            retry_delay_seconds=0,
-        )
-        assert result == b"recovered"
-        assert len(pool.calls) == 2
-
-    def test_connection_error_then_200_retries(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        pool = make_pool(
-            [urllib3.exceptions.TimeoutError("timed out"), FakeResponse(200, b"ok")],
-            monkeypatch,
-        )
-        result = http_mod.http_get(
-            "http://example.com",
-            {},
-            timeout_seconds=5,
-            request_retries=3,
-            retry_delay_seconds=0,
-        )
-        assert result == b"ok"
-        assert len(pool.calls) == 2
-
-    def test_connection_error_exhausts_retries(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        make_pool([urllib3.exceptions.TimeoutError("timed out")] * 3, monkeypatch)
-        with pytest.raises(urllib3.exceptions.TimeoutError):
-            http_mod.http_get(
-                "http://example.com",
-                {},
-                timeout_seconds=5,
-                request_retries=3,
-                retry_delay_seconds=0,
-            )
-
-    def test_backoff_grows_exponentially_and_is_capped(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        make_pool([FakeResponse(500)] * 3 + [FakeResponse(200)], monkeypatch)
-        sleeps: list[float] = []
-        monkeypatch.setattr(http_mod.time, "sleep", sleeps.append)
-        monkeypatch.setattr(http_mod.random, "uniform", lambda low, high: high)
-
+        pool = capturing_pool(FakeResponse(200))
         http_mod.http_get(
             "http://example.com",
             {},
@@ -177,5 +114,124 @@ class TestHttpGet:
             request_retries=4,
             retry_delay_seconds=10,
         )
+        retries = pool.calls[0][2]["retries"]
+        assert isinstance(retries, Retry)
+        assert retries.total == 3
+        assert set(retries.status_forcelist or set()) == {429, 500, 502, 503, 504}
+        assert retries.backoff_factor == 10
+        assert retries.backoff_max == http_mod._MAX_BACKOFF_SECONDS
+        assert retries.backoff_jitter == 10
+        assert retries.respect_retry_after_header is True
+        assert retries.raise_on_status is False
 
-        assert sleeps == [10, 20, 40]
+
+ServerFactory = Callable[
+    [list[tuple[int, dict[str, str], bytes]]], tuple[str, "list[str]"]
+]
+
+
+@pytest.fixture
+def http_server() -> Iterator[ServerFactory]:
+    """Start throwaway localhost HTTP servers that replay a fixed response sequence.
+
+    Returns a factory taking a list of ``(status, headers, body)`` tuples; the
+    last entry is repeated once the sequence is exhausted. The factory yields
+    the base URL and a list that accumulates the paths the server received.
+    """
+    started: list[ThreadingHTTPServer] = []
+
+    def _start(
+        responses: list[tuple[int, dict[str, str], bytes]],
+    ) -> tuple[str, list[str]]:
+        received: list[str] = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                index = min(len(received), len(responses) - 1)
+                received.append(self.path)
+                status, headers, body = responses[index]
+                self.send_response(status)
+                for name, value in headers.items():
+                    self.send_header(name, value)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args: Any) -> None:
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        started.append(server)
+        return f"http://127.0.0.1:{server.server_address[1]}", received
+
+    yield _start
+
+    for server in started:
+        server.shutdown()
+
+
+class TestRetryIntegration:
+    """End-to-end checks that the Retry policy is actually wired into the request."""
+
+    def test_transient_status_then_success(self, http_server: ServerFactory) -> None:
+        url, received = http_server(
+            [
+                (503, {"Retry-After": "0"}, b""),
+                (200, {}, b"recovered"),
+            ]
+        )
+        result = http_mod.http_get(
+            url,
+            {},
+            timeout_seconds=5,
+            request_retries=3,
+            retry_delay_seconds=0,
+        )
+        assert result == b"recovered"
+        assert len(received) == 2
+
+    def test_transient_status_exhausts_retries(
+        self, http_server: ServerFactory
+    ) -> None:
+        url, received = http_server([(503, {}, b"")])
+        with pytest.raises(urllib3.exceptions.ResponseError, match="HTTP 503"):
+            http_mod.http_get(
+                url,
+                {},
+                timeout_seconds=5,
+                request_retries=2,
+                retry_delay_seconds=0,
+            )
+        assert len(received) == 2
+
+    def test_retry_after_header_is_respected(self, http_server: ServerFactory) -> None:
+        url, _ = http_server(
+            [
+                (503, {"Retry-After": "1"}, b""),
+                (200, {}, b"ok"),
+            ]
+        )
+        start = time.monotonic()
+        result = http_mod.http_get(
+            url,
+            {},
+            timeout_seconds=5,
+            request_retries=3,
+            retry_delay_seconds=0,
+        )
+        elapsed = time.monotonic() - start
+        assert result == b"ok"
+        assert elapsed >= 1.0
+
+    def test_connection_failure_raises_httperror(self) -> None:
+        # Port 1 is reserved and never listening, so the connection fails fast.
+        with pytest.raises(urllib3.exceptions.HTTPError):
+            http_mod.http_get(
+                "http://127.0.0.1:1",
+                {},
+                timeout_seconds=1,
+                request_retries=1,
+                retry_delay_seconds=0,
+            )


### PR DESCRIPTION
The hand-rolled retry loop reimplemented a subset of urllib3's Retry; using a Retry object instead also brings native Retry-After support for 429/503 responses. raise_on_status=False preserves http_get's existing ResponseError contract for persistent error statuses.

Tests rewritten around throwaway localhost servers for end-to-end retry behaviour, plus a capturing fake pool for http_get's own logic.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--297.org.readthedocs.build/en/297/

<!-- readthedocs-preview pysmo end -->