### PR TITLE
docs: drop unenforceable datum claim from depth docstrings

### DIFF
--- a/docs/usage/conventions.md
+++ b/docs/usage/conventions.md
@@ -23,8 +23,8 @@ Mismatched units are a common source of errors and tedious format conversions.
 Pysmo assumes [SI](https://en.wikipedia.org/wiki/International_System_of_Units)
 units throughout, even where other conventions are common in seismology. This is
 also consistent with e.g. [`scipy.constants`][]. A notable example is
-[`depth`][pysmo.LocationWithDepth.depth], which is in metres (positive downward
-from the surface) — many seismological tools use kilometres instead.
+[`depth`][pysmo.LocationWithDepth.depth], which is in metres (positive
+downwards) — many seismological tools use kilometres instead.
 
 ## Time
 

--- a/src/pysmo/_types/event.py
+++ b/src/pysmo/_types/event.py
@@ -63,4 +63,4 @@ class MiniEvent:
     depth: float = field(
         converter=float, on_setattr=setters.pipe(setters.convert, setters.validate)
     )
-    """Event depth in metres (positive downward from the surface)."""
+    """Event depth in metres, positive downwards."""

--- a/src/pysmo/_types/location_with_depth.py
+++ b/src/pysmo/_types/location_with_depth.py
@@ -12,7 +12,7 @@ class LocationWithDepth(Location, Protocol):
     """Protocol class to define the `LocationWithDepth` type."""
 
     depth: float
-    """Location depth in metres (positive downward from the surface)."""
+    """Location depth in metres, positive downwards."""
 
 
 @define(kw_only=True)
@@ -48,4 +48,4 @@ class MiniLocationWithDepth:
     depth: float = field(
         converter=float, on_setattr=setters.pipe(setters.convert, setters.validate)
     )
-    """Location depth in metres (positive downward from the surface)."""
+    """Location depth in metres, positive downwards."""


### PR DESCRIPTION
depth stays "positive downwards" (a real contract for travel-time calls) but "from the surface" is format-specific and wrong for QuakeML, whose depth is relative to sea level.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--298.org.readthedocs.build/en/298/

<!-- readthedocs-preview pysmo end -->