### PR TITLE
fix(project): discard cache write when parameters change mid-fetch

### DIFF
--- a/src/pysmo/tools/project/_project.py
+++ b/src/pysmo/tools/project/_project.py
@@ -131,6 +131,11 @@ class PysmoProject[T]:
         itself, though: `fetch_seismogram` is called outside the lock, so
         two threads racing the same not-yet-cached entry both still fetch
         before one result wins and is cached.
+
+        Reassigning a window parameter (`phase`, `pre_pick`, …) on one
+        thread while another is mid-fetch is also safe: the in-flight fetch
+        still returns a result, it just isn't cached (the next call
+        recomputes it with the current parameters).
     """
 
     entries: list[ProjectEntry] = field(
@@ -248,6 +253,11 @@ class PysmoProject[T]:
     _cache: dict[_CacheKey, tuple[str, T]] = field(
         init=False, factory=dict, repr=False, eq=False
     )
+    _cache_generation: int = field(init=False, default=0, repr=False, eq=False)
+    """Bumped by every `clear_cache()`. A `_fetch` in progress when the cache
+    is cleared (e.g. a parameter reassigned on another thread mid-download)
+    sees the mismatch and returns its result without caching it under a
+    now-stale key."""
     _lock: threading.Lock = field(
         init=False, factory=threading.Lock, repr=False, eq=False
     )
@@ -256,7 +266,7 @@ class PysmoProject[T]:
 
     def __getstate__(self) -> dict:
         """Drop the fetch cache and lock, neither of which can survive pickling."""
-        state = attrs_getstate(self, {"_cache": {}})
+        state = attrs_getstate(self, {"_cache": {}, "_cache_generation": 0})
         del state["_lock"]
         return state
 
@@ -283,7 +293,9 @@ class PysmoProject[T]:
         `remove`, or index assignment), which isn't observable by
         `on_setattr` and therefore doesn't clear the cache automatically.
         """
-        self._cache.clear()
+        with self._lock:
+            self._cache.clear()
+            self._cache_generation += 1
 
     def _resolve_window(
         self, entry: ProjectEntry
@@ -361,6 +373,7 @@ class PysmoProject[T]:
         )
         with self._lock:
             cached = self._cache.get(key)
+            generation = self._cache_generation
         if cached is None:
             # Deliberately outside the lock — see the class docstring's
             # thread-safety note: two threads racing the same not-yet-cached
@@ -374,9 +387,15 @@ class PysmoProject[T]:
                 endtime=endtime,
                 predicted=predicted,
             )
-            cached = (checksum, self.transform(seismogram, context))
+            fresh = (checksum, self.transform(seismogram, context))
             with self._lock:
-                cached = self._cache.setdefault(key, cached)
+                if self._cache_generation == generation:
+                    cached = self._cache.setdefault(key, fresh)
+                else:
+                    # A parameter changed (clearing the cache) while this
+                    # fetch was in flight: `key` doesn't encode it, so return
+                    # this result once without caching it under a stale key.
+                    cached = fresh
 
         checksum, result = cached
         if entry.checksum is None:

--- a/tests/tools/project/test_project.py
+++ b/tests/tools/project/test_project.py
@@ -422,6 +422,12 @@ class TestCacheInvalidation:
         project.seismogram(station_anmo, event_maule)
         assert len(FETCH_CALLS) == 1
 
+    def test_clear_cache_bumps_generation(self, project: PysmoProject) -> None:
+        assert project._cache_generation == 0
+        project.clear_cache()
+        project.clear_cache()
+        assert project._cache_generation == 2
+
 
 class TestSeismogramsFor:
     def test_one_result_per_station_in_order(
@@ -463,8 +469,12 @@ class TestPickling:
         project.seismogram(station_anmo, event_maule)
         assert len(project._cache) == 1
 
+        project.clear_cache()
+        assert project._cache_generation == 1
+
         restored: PysmoProject = pickle.loads(pickle.dumps(project))
         assert len(restored._cache) == 0
+        assert restored._cache_generation == 0
         assert isinstance(restored._lock, type(threading.Lock()))
 
         restored.seismogram(station_anmo, event_maule)
@@ -524,6 +534,43 @@ class TestThreadSafety:
         assert len(results) == 8
         assert all(result is results[0] for result in results)
         assert len(project._cache) == 1
+
+    def test_parameter_change_mid_fetch_returns_result_uncached(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        fetch_started = threading.Event()
+        may_finish = threading.Event()
+
+        def blocking_fetch(
+            station: Station, starttime: pd.Timestamp, endtime: pd.Timestamp
+        ) -> Seismogram:
+            fetch_started.set()
+            may_finish.wait(timeout=5)
+            return fake_fetch_seismogram(station, starttime, endtime)
+
+        project: PysmoProject = PysmoProject(
+            entries=[ProjectEntry(station=station_anmo, event=event_maule)],
+            transform=identity_transform,
+            fetch_seismogram=blocking_fetch,
+            travel_time_backend=fake_travel_time_backend,
+        )
+        results: list[Seismogram] = []
+
+        def worker() -> None:
+            results.append(project.seismogram(station_anmo, event_maule))
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        assert fetch_started.wait(timeout=5)
+        project.phase = "S"  # clears the cache and bumps the generation
+        may_finish.set()
+        thread.join(timeout=5)
+
+        assert len(results) == 1  # the in-flight fetch still returned a result
+        assert project._cache == {}  # but it was not cached under the stale key
+
+        project.seismogram(station_anmo, event_maule)
+        assert len(FETCH_CALLS) == 2  # so the next call re-fetches
 
 
 class TestChecksum:


### PR DESCRIPTION
PysmoProject._fetch releases the lock for the download; a concurrent reassignment of phase/pre_pick/etc. clears the cache, but the in-flight fetch would then still write its now-stale result under a key that doesn't encode those parameters. Track a generation counter bumped by clear_cache() and skip the cache write if it moved while fetching.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--299.org.readthedocs.build/en/299/

<!-- readthedocs-preview pysmo end -->