### PR TITLE
refactor(types): extract StationCode protocol from Station

### DIFF
--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -232,8 +232,8 @@ the distance between two geographic locations. That is exactly why pysmo has the
 
 Because these types are meant to be very stable, we can do something that is
 often considered bad practice: class inheritance. In pysmo the
-[`Location`][pysmo.Location] type is reused in the [`Station`][pysmo.Station]
-type via inheritance:
+[`Station`][pysmo.Station] type inherits from two smaller types,
+[`Location`][pysmo.Location] and [`StationCode`][pysmo.StationCode]:
 
 <!-- skip: next -->
 
@@ -244,8 +244,10 @@ type via inheritance:
 The result of this is that the [`Station`][pysmo.Station] type gets the
 [`latitude`][pysmo.Location.latitude] and
 [`longitude`][pysmo.Location.longitude] attributes from
-[`Location`][pysmo.Location]. This means [`Station`][pysmo.Station] classes can
-be used as input in functions annotated with [`Location`][pysmo.Location].
+[`Location`][pysmo.Location], and `name`/`network`/`location`/`channel` from
+[`StationCode`][pysmo.StationCode]. This means [`Station`][pysmo.Station]
+classes can be used as input in functions annotated with either
+[`Location`][pysmo.Location] or [`StationCode`][pysmo.StationCode].
 
 In summary, the strategy for determining types can be summarised as follows:
 

--- a/src/pysmo/__init__.py
+++ b/src/pysmo/__init__.py
@@ -32,11 +32,13 @@ from ._types import (
     MiniSeismogram,
     MiniStagedResponse,
     MiniStation,
+    MiniStationCode,
     Response,
     ResponseStage,
     Seismogram,
     StagedResponse,
     Station,
+    StationCode,
 )
 from ._utils import export_module_names
 
@@ -45,6 +47,7 @@ __version__ = version("pysmo")
 type _BaseProto = (
     Seismogram
     | Station
+    | StationCode
     | Event
     | Location
     | LocationWithDepth
@@ -55,6 +58,7 @@ type _BaseProto = (
 type _BaseMini = (
     MiniSeismogram
     | MiniStation
+    | MiniStationCode
     | MiniEvent
     | MiniLocation
     | MiniLocationWithDepth
@@ -67,6 +71,7 @@ type _BaseMini = (
 __all__ = [
     "Seismogram",
     "Station",
+    "StationCode",
     "Event",
     "Location",
     "LocationWithDepth",
@@ -75,6 +80,7 @@ __all__ = [
     "ResponseStage",
     "MiniSeismogram",
     "MiniStation",
+    "MiniStationCode",
     "MiniEvent",
     "MiniLocation",
     "MiniLocationWithDepth",

--- a/src/pysmo/_types/station.py
+++ b/src/pysmo/_types/station.py
@@ -4,14 +4,19 @@ from attrs import converters, define, field, setters, validators
 
 from .location import Location
 
-__all__ = ["Station", "MiniStation"]
+__all__ = ["StationCode", "Station", "MiniStationCode", "MiniStation"]
 
 # --8<-- [start:station-protocol]
 
 
 @runtime_checkable
-class Station(Location, Protocol):
-    """Protocol class to define the `Station` type."""
+class StationCode(Protocol):
+    """Protocol class to define the `StationCode` type.
+
+    Network/station/location/channel (NSLC) identity for a data stream,
+    independent of geographic location — the subset of `Station` a format
+    like miniSEED can provide without coordinates.
+    """
 
     name: str
     """Station name or identifier.
@@ -42,6 +47,11 @@ class Station(Location, Protocol):
     3. Orientation of the sensor.
     """
 
+
+@runtime_checkable
+class Station(Location, StationCode, Protocol):
+    """Protocol class to define the `Station` type."""
+
     elevation: int | float | None
     """Station elevation in metres."""
 
@@ -51,6 +61,59 @@ class Station(Location, Protocol):
 
 def _pad_string(x: str) -> str:
     return f"{x:>2}"
+
+
+@define(kw_only=True)
+class MiniStationCode:
+    """Minimal class for use with the [`StationCode`][pysmo.StationCode] type.
+
+    Examples:
+        ```python
+        >>> from pysmo import MiniStationCode, StationCode
+        >>> code = MiniStationCode(name="CACB", network="BL", channel="BHZ", location="00")
+        >>> isinstance(code, StationCode)
+        True
+        >>>
+        ```
+    """
+
+    name: str = field(
+        validator=[validators.min_len(1), validators.max_len(5)],
+        on_setattr=setters.pipe(setters.convert, setters.validate),
+    )
+    """Station name.
+
+    See [`StationCode.name`][pysmo.StationCode.name] for more details.
+    """
+
+    network: str = field(
+        validator=[validators.min_len(1), validators.max_len(2)],
+        on_setattr=setters.pipe(setters.convert, setters.validate),
+    )
+    """Network name.
+
+    See [`StationCode.network`][pysmo.StationCode.network] for more details.
+    """
+
+    location: str = field(
+        default="  ",
+        validator=[validators.min_len(2), validators.max_len(2)],
+        converter=_pad_string,
+        on_setattr=setters.pipe(setters.convert, setters.validate),
+    )
+    """Location ID.
+
+    See [`StationCode.location`][pysmo.StationCode.location] for more details.
+    """
+
+    channel: str = field(
+        validator=[validators.min_len(3), validators.max_len(3)],
+        on_setattr=setters.pipe(setters.convert, setters.validate),
+    )
+    """Channel code.
+
+    See [`StationCode.channel`][pysmo.StationCode.channel] for more details.
+    """
 
 
 @define(kw_only=True)

--- a/tests/lib/test_mini_utils.py
+++ b/tests/lib/test_mini_utils.py
@@ -7,8 +7,10 @@ from pysmo import (
     MiniLocationWithDepth,
     MiniSeismogram,
     MiniStation,
+    MiniStationCode,
     Seismogram,
     Station,
+    StationCode,
 )
 
 
@@ -67,3 +69,31 @@ def test_matching_pysmo_types() -> None:
     assert set(matching_pysmo_types(MiniEvent)) == set(
         [Location, LocationWithDepth, Event]
     )
+
+
+def test_proto2mini_stationcode_is_one_to_many() -> None:
+    """MiniStation also structurally satisfies StationCode (NSLC subset)."""
+    from pysmo.lib.mini_utils import proto2mini
+
+    assert set(proto2mini(StationCode)) == {MiniStation, MiniStationCode}
+
+
+def test_matching_pysmo_types_ministation_includes_stationcode() -> None:
+    from pysmo.lib.mini_utils import matching_pysmo_types
+
+    station = MiniStation(
+        latitude=-21.68,
+        longitude=-46.73,
+        name="CACB",
+        network="BL",
+        channel="BHZ",
+        location="00",
+    )
+    assert set(matching_pysmo_types(station)) == {Station, StationCode, Location}
+
+
+def test_matching_pysmo_types_ministationcode_is_stationcode_only() -> None:
+    from pysmo.lib.mini_utils import matching_pysmo_types
+
+    code = MiniStationCode(name="CACB", network="BL", channel="BHZ", location="00")
+    assert set(matching_pysmo_types(code)) == {StationCode}


### PR DESCRIPTION
Station now inherits its NSLC fields (name/network/location/channel) from a new StationCode protocol, keeping only elevation of its own on top of Location. Conformance is structural so every existing Station consumer is unaffected. Adds MiniStationCode and wires both new names into __all__ and the _BaseProto/_BaseMini discovery unions.

This lets a coordinate-free format (miniSEED) expose NSLC identity as real StationCode conformance rather than ad hoc properties.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--300.org.readthedocs.build/en/300/

<!-- readthedocs-preview pysmo end -->