### PR TITLE
feat(stationxml): narrow from_bytes epochs by network and station

### DIFF
--- a/src/pysmo/classes/_stationxml.py
+++ b/src/pysmo/classes/_stationxml.py
@@ -27,9 +27,15 @@ def _matching_epochs(
     epochs: list[_RawResponse],
     time: pd.Timestamp | None,
     *,
+    network: str | None = None,
+    station: str | None = None,
     location: str | None = None,
     channel: str | None = None,
 ) -> list[_RawResponse]:
+    if network is not None:
+        epochs = [epoch for epoch in epochs if epoch.network == network]
+    if station is not None:
+        epochs = [epoch for epoch in epochs if epoch.station == station]
     if location is not None:
         epochs = [epoch for epoch in epochs if epoch.location == location]
     if channel is not None:
@@ -189,23 +195,30 @@ class StationXML:
         xml: bytes,
         *,
         time: pd.Timestamp | None = None,
+        network: str | None = None,
+        station: str | None = None,
         location: str | None = None,
         channel: str | None = None,
     ) -> Self:
         """Create a new instance from a StationXML document, selecting one epoch.
 
-        A document is not guaranteed to cover a single channel — a
-        station-level query (or one saved for later, offline use) commonly
-        returns every location/channel combination on record, each with its
-        own epoch history. `location`/`channel` narrow to one before `time`
-        is applied; without them, a multi-channel document raises the same
-        "more than one epoch" error as an ambiguous *time*.
+        A document is not guaranteed to cover a single channel — a bulk or
+        wildcard query (or one saved for later, offline use) can cover
+        several networks and stations, each with every location/channel
+        combination on record and its own epoch history.
+        `network`/`station`/`location`/`channel` narrow to one before *time*
+        is applied; without them, a document covering more than one raises
+        the same "more than one epoch" error as an ambiguous *time*.
 
         Args:
             xml: Raw StationXML document bytes (as returned by the FDSN
                 station web service with `level=response`).
             time: Timestamp used to select the response epoch. If `None`,
                 the currently-open epoch (no end date) is selected.
+            network: Network code to narrow to, if `xml` covers more than
+                one network. If `None`, network is not filtered.
+            station: Station code to narrow to, if `xml` covers more than
+                one station. If `None`, station is not filtered.
             location: Location code to narrow to, if `xml` covers more than
                 one location. If `None`, location is not filtered.
             channel: Channel code to narrow to, if `xml` covers more than
@@ -216,21 +229,31 @@ class StationXML:
             *time* (or currently open, if `time` is `None`).
 
         Raises:
-            ValueError: If, after narrowing by `location`/`channel`, zero or
-                more than one response epoch matches *time* (or "currently
-                open", if `time` is `None`).
+            ValueError: If, after narrowing by
+                `network`/`station`/`location`/`channel`, zero or more than
+                one response epoch matches *time* (or "currently open", if
+                `time` is `None`).
 
         Tip: See Also
             [`StationXML.all_from_bytes`][pysmo.classes.StationXML.all_from_bytes]:
             Parse every epoch in the document without narrowing to one.
         """
         epochs = parse_stationxml(xml)
-        matches = _matching_epochs(epochs, time, location=location, channel=channel)
+        matches = _matching_epochs(
+            epochs,
+            time,
+            network=network,
+            station=station,
+            location=location,
+            channel=channel,
+        )
         if len(matches) != 1:
             raise ValueError(
                 f"Expected exactly one response epoch in the given "
                 f"StationXML at "
                 f"{'the currently open epoch' if time is None else time}"
+                f"{f', network {network!r}' if network is not None else ''}"
+                f"{f', station {station!r}' if station is not None else ''}"
                 f"{f', location {location!r}' if location is not None else ''}"
                 f"{f', channel {channel!r}' if channel is not None else ''}, "
                 f"found {len(matches)}."

--- a/tests/classes/test_stationxml_class.py
+++ b/tests/classes/test_stationxml_class.py
@@ -132,6 +132,65 @@ MULTIPLE_LOCATIONS_AND_CHANNELS = b"""\
 """
 
 
+def _station_block(station: str, sensitivity: str, pole: str) -> str:
+    return f"""\
+    <Station code="{station}">
+      <Channel code="BHZ" locationCode="00" startDate="2000-01-01T00:00:00.0000">
+        <Response>
+          <InstrumentSensitivity>
+            <Value>{sensitivity}</Value>
+            <InputUnits><Name>m/s</Name></InputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>1.0</NormalizationFactor>
+              <Zero number="0"><Real>0.0</Real><Imaginary>0.0</Imaginary></Zero>
+              <Pole number="0"><Real>{pole}</Real><Imaginary>0.0</Imaginary></Pole>
+            </PolesZeros>
+            <Decimation><InputSampleRate>40.0</InputSampleRate><Factor>1</Factor></Decimation>
+            <StageGain><Value>1.0</Value><Frequency>1.0</Frequency></StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+    </Station>
+"""
+
+
+def _document(*networks: str) -> bytes:
+    body = "".join(networks)
+    return (
+        '<?xml version="1.0"?>\n'
+        '<FDSNStationXML xmlns="http://www.fdsn.org/xml/station/1">\n'
+        f"{body}"
+        "</FDSNStationXML>\n"
+    ).encode()
+
+
+def _network_block(network: str, *station_blocks: str) -> str:
+    return (
+        f'  <Network code="{network}">\n' + "".join(station_blocks) + "  </Network>\n"
+    )
+
+
+# Two networks sharing the same station/location/channel codes -- only
+# `network` disambiguates.
+MULTIPLE_NETWORKS = _document(
+    _network_block("IU", _station_block("ANMO", "1.0E9", "-1.0")),
+    _network_block("II", _station_block("ANMO", "2.0E9", "-2.0")),
+)
+
+# One network, two stations sharing the same location/channel codes -- only
+# `station` disambiguates.
+MULTIPLE_STATIONS = _document(
+    _network_block(
+        "IU",
+        _station_block("ANMO", "1.0E9", "-1.0"),
+        _station_block("COLA", "2.0E9", "-2.0"),
+    )
+)
+
+
 class TestFromBytes:
     def test_single_epoch_fixture(self) -> None:
         response = StationXML.from_bytes(
@@ -207,6 +266,31 @@ class TestFromBytes:
         assert response.location == "10"
         assert response.channel == "BHZ"
         assert response.reference_sensitivity == pytest.approx(3.0e9)
+
+    def test_multiple_networks_raise_without_network_narrowing(self) -> None:
+        with pytest.raises(ValueError, match="found 2"):
+            StationXML.from_bytes(MULTIPLE_NETWORKS)
+
+    def test_network_narrows_to_one_epoch(self) -> None:
+        response = StationXML.from_bytes(MULTIPLE_NETWORKS, network="II")
+
+        assert response.network == "II"
+        assert response.station == "ANMO"
+        assert response.reference_sensitivity == pytest.approx(2.0e9)
+
+    def test_multiple_stations_raise_without_station_narrowing(self) -> None:
+        with pytest.raises(ValueError, match="found 2"):
+            StationXML.from_bytes(MULTIPLE_STATIONS)
+
+    def test_station_narrows_to_one_epoch(self) -> None:
+        response = StationXML.from_bytes(MULTIPLE_STATIONS, station="COLA")
+
+        assert response.station == "COLA"
+        assert response.reference_sensitivity == pytest.approx(2.0e9)
+
+    def test_error_message_lists_network_and_station_narrowing(self) -> None:
+        with pytest.raises(ValueError, match="network 'XX', station 'YY'"):
+            StationXML.from_bytes(MULTIPLE_NETWORKS, network="XX", station="YY")
 
 
 class TestAllFromBytes:


### PR DESCRIPTION
A bulk or wildcard StationXML document can cover several networks and stations sharing location/channel codes, which location/channel filtering alone can't disambiguate. from_bytes and _matching_epochs gain network and station parameters, filtered like the existing ones and named in the "more than one epoch" error.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--301.org.readthedocs.build/en/301/

<!-- readthedocs-preview pysmo end -->