### PR TITLE
refactor(classes): rename StationXML to StationXMLResponse

### DIFF
--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -293,7 +293,7 @@ way [`Seismogram`][pysmo.Seismogram] is, just extended differently in practice.
 The third is an **internal-refactor type**: it exists purely to let a pysmo
 function type-check, not because anything outside pysmo needed naming.
 `_EpochProvenance` (`src/pysmo/_types/response.py`) is the current example: both
-[`SacPZ`][pysmo.classes.SacPZ] and [`StationXML`][pysmo.classes.StationXML]
+[`SacPZ`][pysmo.classes.SacPZ] and [`StationXMLResponse`][pysmo.classes.StationXMLResponse]
 carry the same six fields — network, station, location, and channel code, plus a
 start and (optional) end date for the response epoch — because
 [`write_sacpz`][pysmo.lib.io.write_sacpz] needed a name for that overlap to
@@ -317,7 +317,7 @@ correlate with origin without being defined by it.
 A `Mini*` class exists only when some real code path needs to construct a bare
 instance of exactly that type's fields on its own. `_EpochProvenance` has no
 `MiniEpochProvenance` because nothing does: every real caller already has a
-[`SacPZ`][pysmo.classes.SacPZ] or [`StationXML`][pysmo.classes.StationXML]
+[`SacPZ`][pysmo.classes.SacPZ] or [`StationXMLResponse`][pysmo.classes.StationXMLResponse]
 object carrying those six fields as part of something bigger. That is a fact
 about how the type is actually used, not a consequence of it being an
 internal-refactor type — a future internal-refactor type whose callers *do* need

--- a/src/pysmo/_types/response.py
+++ b/src/pysmo/_types/response.py
@@ -155,7 +155,7 @@ class _EpochProvenance(Protocol):
     only so `pysmo.lib.io.write_sacpz` (via `ResponseWithEpoch`) can
     type-check, not to be implemented by third-party code directly. Real
     callers already satisfy it structurally as part of a bigger object
-    (`SacPZ`, `StationXML`), so it is deliberately not exported at the
+    (`SacPZ`, `StationXMLResponse`), so it is deliberately not exported at the
     `pysmo` root namespace.
     """
 

--- a/src/pysmo/classes/__init__.py
+++ b/src/pysmo/classes/__init__.py
@@ -9,7 +9,7 @@ pysmo function or tool that operates on pysmo types.
 
 Each class is designed with the protocol(s) it implements in mind, not to
 reproduce its native format's full specification. The scope isn't strictly
-limited to protocol attributes — [`pysmo.classes.StationXML`][], for
+limited to protocol attributes — [`pysmo.classes.StationXMLResponse`][], for
 example, also carries epoch bookkeeping (network/station/location/channel/
 start_date/end_date) needed to select the right response from a document —
 but the protocol is the organising goal, not fidelity to the format.

--- a/src/pysmo/classes/_sacpz.py
+++ b/src/pysmo/classes/_sacpz.py
@@ -183,7 +183,7 @@ class SacPZ:
     def fetch(cls, *, station: Station, time: pd.Timestamp | None = None) -> Self:
         """Fetch and parse an instrument response from the EarthScope SACPZ web service, selecting one epoch.
 
-        Unlike [`StationXML.fetch`][pysmo.classes.StationXML.fetch], epoch
+        Unlike [`StationXMLResponse.fetch`][pysmo.classes.StationXMLResponse.fetch], epoch
         selection happens server-side: the SACPZ web service's own `time`
         parameter is passed through, so exactly one record is returned
         (the epoch active at *time* if given, otherwise the one currently
@@ -212,10 +212,9 @@ class SacPZ:
         Tip: Prefer StationXML for live fetches
             When fetching live from EarthScope rather than reading an
             existing SAC PZ file, prefer
-            [`StationXML.fetch`][pysmo.classes.StationXML.fetch]: the
-            StationXML response also captures digital FIR/IIR stages, so it
-            always satisfies [`StagedResponse`][pysmo.StagedResponse], unlike
-            `SacPZ`.
+            [`StationXMLResponse.fetch`][pysmo.classes.StationXMLResponse.fetch]:
+            it also captures digital FIR/IIR stages, so it always satisfies
+            [`StagedResponse`][pysmo.StagedResponse], unlike `SacPZ`.
 
         Examples:
             <!-- skip: start if(not run_real_web_requests) -->

--- a/src/pysmo/classes/_stationxml.py
+++ b/src/pysmo/classes/_stationxml.py
@@ -15,7 +15,7 @@ from pysmo.lib.validators import (
 from pysmo.tools.web import fetch_stationxml
 from pysmo.typing import NonZeroNumber
 
-__all__ = ["StationXML"]
+__all__ = ["StationXMLResponse"]
 
 
 def _convert_optional_float(value: float | None) -> float | None:
@@ -52,7 +52,7 @@ def _matching_epochs(
 
 
 @define(kw_only=True)
-class StationXML:
+class StationXMLResponse:
     r"""Import class for FDSN StationXML response metadata.
 
     Reads an instrument response from a
@@ -60,21 +60,21 @@ class StationXML:
     returned by e.g. the EarthScope station web service with
     `level=response`) and exposes it as a
     [`Response`][pysmo.Response]-compatible object. Unlike
-    [`SacPZ`][pysmo.classes.SacPZ], `StationXML` always satisfies
+    [`SacPZ`][pysmo.classes.SacPZ], `StationXMLResponse` always satisfies
     [`StagedResponse`][pysmo.StagedResponse] too — `stages` is simply empty
     if the document has no digital FIR/IIR decimation stages.
 
     A StationXML document commonly covers a channel's full instrument
     history, i.e. several response epochs (e.g. after a sensor swap).
-    [`from_bytes`][pysmo.classes.StationXML.from_bytes] narrows this to a
+    [`from_bytes`][pysmo.classes.StationXMLResponse.from_bytes] narrows this to a
     single epoch (matching a given time, or the currently-open one);
-    [`all_from_bytes`][pysmo.classes.StationXML.all_from_bytes] returns
+    [`all_from_bytes`][pysmo.classes.StationXMLResponse.all_from_bytes] returns
     every epoch found, for callers who want to do their own selection.
 
     Examples:
         ```python
         >>> from pysmo import Response, StagedResponse
-        >>> from pysmo.classes import StationXML
+        >>> from pysmo.classes import StationXMLResponse
         >>> xml = b'''\
         ... <?xml version="1.0"?>
         ... <FDSNStationXML xmlns="http://www.fdsn.org/xml/station/1">
@@ -110,7 +110,7 @@ class StationXML:
         ...     </Station>
         ...   </Network>
         ... </FDSNStationXML>'''
-        >>> response = StationXML.from_bytes(xml)
+        >>> response = StationXMLResponse.from_bytes(xml)
         >>> isinstance(response, Response)
         True
         >>> isinstance(response, StagedResponse)
@@ -225,7 +225,7 @@ class StationXML:
                 one channel. If `None`, channel is not filtered.
 
         Returns:
-            A new StationXML instance for the response epoch active at
+            A new StationXMLResponse instance for the response epoch active at
             *time* (or currently open, if `time` is `None`).
 
         Raises:
@@ -235,7 +235,7 @@ class StationXML:
                 `time` is `None`).
 
         Tip: See Also
-            [`StationXML.all_from_bytes`][pysmo.classes.StationXML.all_from_bytes]:
+            [`StationXMLResponse.all_from_bytes`][pysmo.classes.StationXMLResponse.all_from_bytes]:
             Parse every epoch in the document without narrowing to one.
         """
         epochs = parse_stationxml(xml)
@@ -269,11 +269,11 @@ class StationXML:
         the epoch active at *time* if given, otherwise the one currently
         open (no `endDate`). Fetches the full response history in one
         request and narrows client-side (like
-        [`from_bytes`][pysmo.classes.StationXML.from_bytes]); to fetch once
+        [`from_bytes`][pysmo.classes.StationXMLResponse.from_bytes]); to fetch once
         and interpret later (e.g. offline, or without repeating the network
         request), use [`pysmo.tools.web.fetch_stationxml`][] and
-        [`from_bytes`][pysmo.classes.StationXML.from_bytes] /
-        [`all_from_bytes`][pysmo.classes.StationXML.all_from_bytes] directly
+        [`from_bytes`][pysmo.classes.StationXMLResponse.from_bytes] /
+        [`all_from_bytes`][pysmo.classes.StationXMLResponse.all_from_bytes] directly
         instead.
 
         Args:
@@ -284,7 +284,7 @@ class StationXML:
                 the currently-open epoch (no end date) is selected.
 
         Returns:
-            A new StationXML instance for the response epoch active at
+            A new StationXMLResponse instance for the response epoch active at
             *time* (or currently open, if `time` is `None`).
 
         Raises:
@@ -297,12 +297,12 @@ class StationXML:
             <!-- skip: start if(not run_real_web_requests) -->
             ```python
             >>> from pysmo import MiniStation
-            >>> from pysmo.classes import StationXML
+            >>> from pysmo.classes import StationXMLResponse
             >>> station = MiniStation(
             ...     name="ANMO", network="IU", location="00", channel="BHZ",
             ...     latitude=34.945981, longitude=-106.457133,
             ... )
-            >>> response = StationXML.fetch(station=station)
+            >>> response = StationXMLResponse.fetch(station=station)
             >>>
             ```
             <!-- skip: end -->
@@ -314,7 +314,7 @@ class StationXML:
     def all_from_bytes(cls, xml: bytes) -> list[Self]:
         """Create one instance per response epoch in a StationXML document.
 
-        Unlike [`from_bytes`][pysmo.classes.StationXML.from_bytes], this
+        Unlike [`from_bytes`][pysmo.classes.StationXMLResponse.from_bytes], this
         does not narrow to a single epoch — a document covering a channel's
         full instrument history returns several, each with its own
         `network`/`station`/`location`/`channel`/`start_date`/`end_date`
@@ -324,7 +324,7 @@ class StationXML:
             xml: Raw StationXML document bytes.
 
         Returns:
-            One StationXML instance per response epoch found, in document
+            One StationXMLResponse instance per response epoch found, in document
             order.
         """
         return [cls._from_raw(raw) for raw in parse_stationxml(xml)]

--- a/src/pysmo/lib/io/_sacpz.py
+++ b/src/pysmo/lib/io/_sacpz.py
@@ -45,7 +45,7 @@ class ResponseWithEpoch(Response, _EpochProvenance, Protocol):
     A [`Response`][pysmo.Response] with `_EpochProvenance` (channel identity plus a
     validity window) — what [`write_sacpz`][pysmo.lib.io.write_sacpz] requires. Any
     object satisfying both protocols (e.g. [`SacPZ`][pysmo.classes.SacPZ] or
-    [`StationXML`][pysmo.classes.StationXML]) already satisfies this one structurally;
+    [`StationXMLResponse`][pysmo.classes.StationXMLResponse]) already satisfies this one structurally;
     there is usually no need to reference it directly unless type-annotating a variable
     meant to hold whatever `write_sacpz` accepts.
     """
@@ -281,7 +281,7 @@ def write_sacpz(
         responses: A single object satisfying
             [`ResponseWithEpoch`][pysmo.lib.io.ResponseWithEpoch] (e.g.
             [`SacPZ`][pysmo.classes.SacPZ] or
-            [`StationXML`][pysmo.classes.StationXML]), or a non-empty
+            [`StationXMLResponse`][pysmo.classes.StationXMLResponse]), or a non-empty
             sequence of them.
         path: Destination file path; written in UTF-8 text mode.
 
@@ -297,7 +297,7 @@ def write_sacpz(
         [`SacPZ`][pysmo.classes.SacPZ] instance (which was itself parsed
         from `.6e`-formatted text) back out loses nothing. Writing a
         higher-precision source instead — e.g. a
-        [`StationXML`][pysmo.classes.StationXML] instance, whose XML
+        [`StationXMLResponse`][pysmo.classes.StationXMLResponse] instance, whose XML
         `<Real>`/`<Imaginary>` elements are not limited to 6 decimals —
         does round to this format's conventional precision; that is
         expected when converting into SAC PZ, not a bug to work around

--- a/src/pysmo/lib/io/_stationxml.py
+++ b/src/pysmo/lib/io/_stationxml.py
@@ -5,7 +5,7 @@ This module implements the parsing side of the response-relevant subset of
 `_RawResponse` instances — one per `<Channel>` epoch — without constructing
 any `pysmo` type. Interpretation into a
 [`Response`][pysmo.Response]-compatible object happens one layer up, in
-[`pysmo.classes.StationXML`][].
+[`pysmo.classes.StationXMLResponse`][].
 """
 
 import warnings

--- a/src/pysmo/tools/project/__init__.py
+++ b/src/pysmo/tools/project/__init__.py
@@ -40,7 +40,7 @@ block:
 >>> import pandas as pd
 >>> from attrs import define
 >>> from pysmo import MiniEvent, MiniStation, Seismogram
->>> from pysmo.classes import StationXML
+>>> from pysmo.classes import StationXMLResponse
 >>> from pysmo.functions import clone_to_mini
 >>> from pysmo.tools.iccs import ICCS, MiniIccsSeismogram
 >>> from pysmo.tools.project import FetchContext, ProjectEntry, PysmoProject
@@ -74,7 +74,7 @@ configurable per instance:
 ...     def __call__(
 ...         self, seismogram: Seismogram, context: FetchContext
 ...     ) -> MiniIccsSeismogram:
-...         response = StationXML.fetch(
+...         response = StationXMLResponse.fetch(
 ...             station=context.entry.station, time=context.starttime
 ...         )
 ...         corrected = remove_response(
@@ -131,7 +131,7 @@ rather than re-fetched — recommended for real analysis work, over the
 always-fresh default used above.
 
 This only pins the waveform, though. `to_mini_iccs_seismogram` (reused
-below unchanged) still fetches `StationXML` itself on every call, cached
+below unchanged) still fetches a `StationXMLResponse` itself on every call, cached
 or not — an archive-backed `fetch_seismogram` says nothing about whatever
 `transform` independently fetches:
 

--- a/src/pysmo/tools/project/_project.py
+++ b/src/pysmo/tools/project/_project.py
@@ -156,7 +156,7 @@ class PysmoProject[T]:
     conversion to `T`, since it is the one place every fetch already passes
     through. Free to do anything else it needs — including its own
     additional fetches (e.g. instrument response metadata via
-    [`StationXML.fetch`][pysmo.classes.StationXML.fetch], demonstrated in
+    [`StationXMLResponse.fetch`][pysmo.classes.StationXMLResponse.fetch], demonstrated in
     the [module documentation][pysmo.tools.project]'s own example — this
     design doesn't fetch or know about response data itself, deliberately).
     Must be a top-level function in an importable module — not a lambda or

--- a/src/pysmo/tools/signal/_response.py
+++ b/src/pysmo/tools/signal/_response.py
@@ -112,7 +112,7 @@ def remove_response[T: Seismogram](
     the full-deconvolution path below — are normalised to displacement. This
     is a convention of the *producer*, not something `SacPZ`/`parse_sacpz`
     enforce or verify — a hand-written SAC PZ file that doesn't follow it will
-    not exhibit this split. A [`StationXML`][pysmo.classes.StationXML]-derived
+    not exhibit this split. A [`StationXMLResponse`][pysmo.classes.StationXMLResponse]-derived
     `response` has no such split: both paths agree with `input_units`.
 
     **`pre_filt` given — spectral deconvolution.** Deconvolves `seismogram.data`
@@ -136,11 +136,11 @@ def remove_response[T: Seismogram](
     The right bound for $f_4$ also depends on whether `response` actually carries
     digital FIR/IIR decimation stages — not just whether it satisfies
     [`StagedResponse`][pysmo.StagedResponse], since e.g.
-    [`StationXML`][pysmo.classes.StationXML] always satisfies that protocol but its
+    [`StationXMLResponse`][pysmo.classes.StationXMLResponse] always satisfies that protocol but its
     `stages` is empty for a document with no digital stage on record:
 
     - **No digital stages** (`stages` empty, e.g. a SAC PZ-derived response, or a
-      `StationXML` document without one): only the analog poles/zeros/sensitivity go
+      StationXML document without one): only the analog poles/zeros/sensitivity go
       into $H(f)$. Pushing $f_4$ above roughly 80% of the seismogram's own Nyquist
       frequency triggers the `UserWarning` described below — the analog-only
       approximation ignores the roll-off and phase a real digitiser's decimation
@@ -223,11 +223,11 @@ def remove_response[T: Seismogram](
 
         ```python
         >>> from pathlib import Path
-        >>> from pysmo.classes import SAC, StationXML
+        >>> from pysmo.classes import SAC, StationXMLResponse
         >>> from pysmo.tools.signal import remove_response
         >>> xml = Path("example_response.xml").read_bytes()
         >>> original = SAC.from_file("example.sac").seismogram
-        >>> response = StationXML.from_bytes(xml, time=original.begin_time)
+        >>> response = StationXMLResponse.from_bytes(xml, time=original.begin_time)
         >>> seismogram = remove_response(original, response, clone=True)
         >>> len(seismogram.data) == len(original.data)
         True

--- a/src/pysmo/tools/web.py
+++ b/src/pysmo/tools/web.py
@@ -170,12 +170,12 @@ def fetch_stationxml(*, station: Station) -> bytes:
     """Fetch raw StationXML response metadata bytes for a station/channel.
 
     A lower-level counterpart to
-    [`StationXML.fetch`][pysmo.classes.StationXML.fetch]: returns the
+    [`StationXMLResponse.fetch`][pysmo.classes.StationXMLResponse.fetch]: returns the
     StationXML document unparsed and uninterpreted, covering every response
     epoch on record for the requested channel. Save it to disk to defer
     parsing to later — offline, without another network request — via
-    [`StationXML.from_bytes`][pysmo.classes.StationXML.from_bytes] or
-    [`StationXML.all_from_bytes`][pysmo.classes.StationXML.all_from_bytes].
+    [`StationXMLResponse.from_bytes`][pysmo.classes.StationXMLResponse.from_bytes] or
+    [`StationXMLResponse.all_from_bytes`][pysmo.classes.StationXMLResponse.all_from_bytes].
 
     Args:
         station: Any object satisfying the [`Station`][pysmo.Station]

--- a/tests/classes/test_stationxml_class.py
+++ b/tests/classes/test_stationxml_class.py
@@ -1,4 +1,4 @@
-"""Tests for pysmo.classes.StationXML."""
+"""Tests for pysmo.classes.StationXMLResponse."""
 
 from pathlib import Path
 
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from pysmo import MiniStation, Response, StagedResponse
-from pysmo.classes import StationXML
+from pysmo.classes import StationXMLResponse
 
 SINGLE_EPOCH_FIXTURE = (
     Path(__file__).parent.parent
@@ -193,7 +193,7 @@ MULTIPLE_STATIONS = _document(
 
 class TestFromBytes:
     def test_single_epoch_fixture(self) -> None:
-        response = StationXML.from_bytes(
+        response = StationXMLResponse.from_bytes(
             SINGLE_EPOCH_FIXTURE.read_bytes(), time=pd.Timestamp("2016-01-01T00:00:00Z")
         )
 
@@ -211,7 +211,7 @@ class TestFromBytes:
         value, distinct from overall_sensitivity (which has the analog
         stage's A0 normalisation factor folded in) — otherwise
         remove_response's sensitivity-only path mis-scales by A0."""
-        response = StationXML.from_bytes(
+        response = StationXMLResponse.from_bytes(
             SINGLE_EPOCH_FIXTURE.read_bytes(), time=pd.Timestamp("2016-01-01T00:00:00Z")
         )
 
@@ -220,14 +220,14 @@ class TestFromBytes:
         assert response.reference_sensitivity == pytest.approx(3.40413e9)
 
     def test_selects_currently_open_epoch(self) -> None:
-        response = StationXML.from_bytes(BULK_FIXTURE.read_bytes())
+        response = StationXMLResponse.from_bytes(BULK_FIXTURE.read_bytes())
 
         assert isinstance(response, StagedResponse)
         assert len(response.poles) == 13
         assert len(response.stages) == 2
 
     def test_selects_historical_epoch_by_time(self) -> None:
-        response = StationXML.from_bytes(
+        response = StationXMLResponse.from_bytes(
             BULK_FIXTURE.read_bytes(), time=pd.Timestamp("1999-01-01T00:00:00Z")
         )
 
@@ -236,13 +236,13 @@ class TestFromBytes:
 
     def test_no_matching_epoch_raises(self) -> None:
         with pytest.raises(ValueError, match="found 0"):
-            StationXML.from_bytes(
+            StationXMLResponse.from_bytes(
                 BULK_FIXTURE.read_bytes(), time=pd.Timestamp("1990-01-01T00:00:00Z")
             )
 
     def test_overlapping_epochs_raise(self) -> None:
         with pytest.raises(ValueError, match="found 2"):
-            StationXML.from_bytes(
+            StationXMLResponse.from_bytes(
                 OVERLAPPING_EPOCHS, time=pd.Timestamp("2010-01-01T00:00:00Z")
             )
 
@@ -252,14 +252,16 @@ class TestFromBytes:
         # without location/channel narrowing this is as ambiguous as
         # overlapping epochs.
         with pytest.raises(ValueError, match="found 3"):
-            StationXML.from_bytes(MULTIPLE_LOCATIONS_AND_CHANNELS)
+            StationXMLResponse.from_bytes(MULTIPLE_LOCATIONS_AND_CHANNELS)
 
     def test_channel_alone_narrows_but_may_still_be_ambiguous(self) -> None:
         with pytest.raises(ValueError, match="found 2"):
-            StationXML.from_bytes(MULTIPLE_LOCATIONS_AND_CHANNELS, channel="BHZ")
+            StationXMLResponse.from_bytes(
+                MULTIPLE_LOCATIONS_AND_CHANNELS, channel="BHZ"
+            )
 
     def test_location_and_channel_narrow_to_one_epoch(self) -> None:
-        response = StationXML.from_bytes(
+        response = StationXMLResponse.from_bytes(
             MULTIPLE_LOCATIONS_AND_CHANNELS, location="10", channel="BHZ"
         )
 
@@ -269,10 +271,10 @@ class TestFromBytes:
 
     def test_multiple_networks_raise_without_network_narrowing(self) -> None:
         with pytest.raises(ValueError, match="found 2"):
-            StationXML.from_bytes(MULTIPLE_NETWORKS)
+            StationXMLResponse.from_bytes(MULTIPLE_NETWORKS)
 
     def test_network_narrows_to_one_epoch(self) -> None:
-        response = StationXML.from_bytes(MULTIPLE_NETWORKS, network="II")
+        response = StationXMLResponse.from_bytes(MULTIPLE_NETWORKS, network="II")
 
         assert response.network == "II"
         assert response.station == "ANMO"
@@ -280,22 +282,22 @@ class TestFromBytes:
 
     def test_multiple_stations_raise_without_station_narrowing(self) -> None:
         with pytest.raises(ValueError, match="found 2"):
-            StationXML.from_bytes(MULTIPLE_STATIONS)
+            StationXMLResponse.from_bytes(MULTIPLE_STATIONS)
 
     def test_station_narrows_to_one_epoch(self) -> None:
-        response = StationXML.from_bytes(MULTIPLE_STATIONS, station="COLA")
+        response = StationXMLResponse.from_bytes(MULTIPLE_STATIONS, station="COLA")
 
         assert response.station == "COLA"
         assert response.reference_sensitivity == pytest.approx(2.0e9)
 
     def test_error_message_lists_network_and_station_narrowing(self) -> None:
         with pytest.raises(ValueError, match="network 'XX', station 'YY'"):
-            StationXML.from_bytes(MULTIPLE_NETWORKS, network="XX", station="YY")
+            StationXMLResponse.from_bytes(MULTIPLE_NETWORKS, network="XX", station="YY")
 
 
 class TestAllFromBytes:
     def test_real_bulk_fixture(self) -> None:
-        responses = StationXML.all_from_bytes(BULK_FIXTURE.read_bytes())
+        responses = StationXMLResponse.all_from_bytes(BULK_FIXTURE.read_bytes())
         assert len(responses) == 9
         for response in responses:
             assert isinstance(response, Response)
@@ -307,7 +309,7 @@ class TestAllFromBytes:
         assert responses[-1].end_date is None
 
     def test_single_epoch_still_returns_a_list(self) -> None:
-        responses = StationXML.all_from_bytes(SINGLE_EPOCH_FIXTURE.read_bytes())
+        responses = StationXMLResponse.all_from_bytes(SINGLE_EPOCH_FIXTURE.read_bytes())
         assert len(responses) == 1
 
 
@@ -336,7 +338,7 @@ class TestFetch:
 
         monkeypatch.setattr("pysmo.tools.web.http_get", fake_http_get)
 
-        response = StationXML.fetch(
+        response = StationXMLResponse.fetch(
             station=station, time=pd.Timestamp("2016-01-01T00:00:00Z")
         )
 
@@ -360,7 +362,7 @@ class TestFetch:
             lambda *args, **kwargs: BULK_FIXTURE.read_bytes(),
         )
 
-        response = StationXML.fetch(station=station)
+        response = StationXMLResponse.fetch(station=station)
 
         assert isinstance(response, StagedResponse)
         assert len(response.poles) == 13
@@ -374,7 +376,7 @@ class TestFetch:
             lambda *args, **kwargs: BULK_FIXTURE.read_bytes(),
         )
 
-        response = StationXML.fetch(
+        response = StationXMLResponse.fetch(
             station=station, time=pd.Timestamp("1999-01-01T00:00:00Z")
         )
 
@@ -390,7 +392,9 @@ class TestFetch:
         )
 
         with pytest.raises(ValueError, match="found 0"):
-            StationXML.fetch(station=station, time=pd.Timestamp("1990-01-01T00:00:00Z"))
+            StationXMLResponse.fetch(
+                station=station, time=pd.Timestamp("1990-01-01T00:00:00Z")
+            )
 
     def test_overlapping_epochs_raise(
         self, monkeypatch: pytest.MonkeyPatch, station: MiniStation
@@ -401,4 +405,6 @@ class TestFetch:
         )
 
         with pytest.raises(ValueError, match="found 2"):
-            StationXML.fetch(station=station, time=pd.Timestamp("2010-01-01T00:00:00Z"))
+            StationXMLResponse.fetch(
+                station=station, time=pd.Timestamp("2010-01-01T00:00:00Z")
+            )

--- a/tests/integration/test_response_removal_live.py
+++ b/tests/integration/test_response_removal_live.py
@@ -7,7 +7,7 @@ computing a phase-relative window (via
 function's own Examples), fetching a real waveform for it
 ([`GeoCsvSeismogram.fetch`][pysmo.classes.GeoCsvSeismogram.fetch]) and its
 real instrument response
-([`StationXML.fetch`][pysmo.classes.StationXML.fetch]),
+([`StationXMLResponse.fetch`][pysmo.classes.StationXMLResponse.fetch]),
 detrending/tapering it ([`pysmo.functions`][pysmo.functions]), then removing
 the response via both the sensitivity-only and full-deconvolution paths
 ([`remove_response`][pysmo.tools.signal.remove_response]) and plotting the
@@ -36,7 +36,7 @@ from matplotlib.dates import date2num
 from matplotlib.figure import Figure
 
 from pysmo import MiniEvent, MiniStation
-from pysmo.classes import GeoCsvSeismogram, StationXML
+from pysmo.classes import GeoCsvSeismogram, StationXMLResponse
 from pysmo.functions import detrend, taper
 from pysmo.tools.azdist import haversine
 from pysmo.tools.plotutils import plotseis
@@ -85,7 +85,7 @@ def test_remove_response_pipeline_live(
         starttime=predicted_p - pd.Timedelta(minutes=2),
         endtime=predicted_p + pd.Timedelta(minutes=15),
     )
-    response = StationXML.fetch(station=station, time=seismogram.begin_time)
+    response = StationXMLResponse.fetch(station=station, time=seismogram.begin_time)
 
     assert response.network == "IU"
     assert response.station == "ANMO"

--- a/tests/tools/test_web.py
+++ b/tests/tools/test_web.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 from pysmo import MiniStation, Response, StagedResponse
-from pysmo.classes import SacPZ, StationXML
+from pysmo.classes import SacPZ, StationXMLResponse
 from pysmo.tools.web import (
     fetch_sac,
     fetch_sacpz,
@@ -119,7 +119,9 @@ class TestFetchStationxml:
         monkeypatch.setattr("pysmo.tools.web.http_get", fake)
 
         xml = fetch_stationxml(station=station)
-        response = StationXML.from_bytes(xml, time=pd.Timestamp("2016-01-01T00:00:00Z"))
+        response = StationXMLResponse.from_bytes(
+            xml, time=pd.Timestamp("2016-01-01T00:00:00Z")
+        )
 
         assert isinstance(response, Response)
         assert isinstance(response, StagedResponse)


### PR DESCRIPTION
The class only ever exposed one response epoch's poles/zeros/sensitivity, but "StationXML" is a general station-metadata format — the name claimed the whole format while modelling one slice of it. StationXMLResponse matches the <Format><Role> pattern of GeoCsvSeismogram / MSeedSeismogram. Mechanical rename; structural conformance and the fetch_stationxml function name are unchanged.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--302.org.readthedocs.build/en/302/

<!-- readthedocs-preview pysmo end -->