### PR TITLE
fix(web): fetch SAC PZ from fdsnws-station, not the dead irisws-sacpz

### DIFF
--- a/.github/workflows/live-web-tests.yml
+++ b/.github/workflows/live-web-tests.yml
@@ -1,0 +1,61 @@
+name: live web tests
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  live-web-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.14"
+      - name: Sync dependencies
+        run: uv sync --locked --all-extras --no-group docs
+      - name: Run live web tests
+        id: tests
+        run: >
+          uv run pytest --mpl --run-real-web-requests
+          --reruns 3 --reruns-delay 60
+          --only-rerun 'ConnectionError|ReadTimeout|ReadTimeoutError|MaxRetryError|ProtocolError|NewConnectionError|ResponseError'
+          tests/tools/test_web_live.py
+          tests/integration/test_response_removal_live.py
+      - name: Report upstream drift
+        if: always() && steps.tests.conclusion == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Live web tests failing against an upstream service"
+          stamp="$(date -u +%Y-%m-%dT%H:%MZ)"
+          existing="$(gh issue list --state open --json number,labels \
+            --jq '[.[] | select(any(.labels[]; .name == "upstream-drift"))][0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Still failing as of ${stamp} — ${RUN_URL}"
+          else
+            gh label create upstream-drift --color BFD4F2 --force \
+              --description "Live web tests failing against an upstream service"
+            gh issue create --title "$title" --label upstream-drift --body "$(cat <<EOF
+          The scheduled \`live web tests\` workflow failed on ${stamp}.
+
+          Run: ${RUN_URL}
+
+          These tests hit the real EarthScope and USGS web services. A failure here
+          usually means an upstream service changed its URL, request parameters, or
+          response format (as with the \`irisws-sacpz\` retirement), not a pysmo
+          regression. Transient network errors are retried automatically before the
+          job fails.
+
+          Investigate, then close this issue once a later run is green.
+          EOF
+          )"
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ test = [
   "pytest-cov>=6.3.0",
   "pytest-mypy>=1.0.1",
   "pytest-depends>=1.0.1",
+  "pytest-rerunfailures>=16.0",
   "pytest-sugar>=1.1.1",
   "sybil[pytest]>=9.2.0",
   "syrupy>=4.9.1",

--- a/src/pysmo/classes/_sacpz.py
+++ b/src/pysmo/classes/_sacpz.py
@@ -29,8 +29,8 @@ class SacPZ:
 
     Reads an analog instrument response from a
     [SAC PZ](https://ds.iris.edu/files/sac-manual/commands/transfer.html)
-    file (as produced by e.g. the EarthScope SACPZ web service) and exposes
-    it as a [`Response`][pysmo.Response]-compatible object. `SacPZ` only ever
+    file (as produced by e.g. EarthScope's fdsnws-station service) and
+    exposes it as a [`Response`][pysmo.Response]-compatible object. `SacPZ` only ever
     satisfies [`Response`][pysmo.Response], never
     [`StagedResponse`][pysmo.StagedResponse] — the SAC PZ format has no
     digital-stage fields to parse.
@@ -172,23 +172,24 @@ class SacPZ:
 
     @classmethod
     def fetch(cls, *, station: Station, time: pd.Timestamp | None = None) -> Self:
-        """Fetch and parse an instrument response from the EarthScope SACPZ web service, selecting one epoch.
+        """Fetch and parse an instrument response as SAC PZ from EarthScope's fdsnws-station service, selecting one epoch.
+
+        The response comes from `fdsnws-station` with
+        `level=response&format=sacpz`, EarthScope's designated replacement
+        for the `irisws-sacpz` service.
 
         Unlike [`StationXML.fetch`][pysmo.classes.StationXML.fetch], epoch
-        selection happens server-side: the SACPZ web service's own `time`
-        parameter is passed through, so exactly one record is returned
-        (the epoch active at *time* if given, otherwise the one currently
-        open) without needing to fetch the full response history first.
+        selection happens server-side: the web service's `time` parameter
+        is passed through, so exactly one record is returned (the epoch
+        active at *time* if given, otherwise the one currently open)
+        without needing to fetch the full response history first.
 
         Args:
             station: Any object satisfying the [`Station`][pysmo.Station]
                 protocol. Provides the network, station code, location, and
                 channel for the request.
             time: Timestamp used to select the response epoch. If `None`,
-                the currently-open epoch is selected. See
-                [`fetch_sacpz`][pysmo.tools.web.fetch_sacpz] for the
-                sub-second-precision truncation applied before the request
-                is sent.
+                the currently-open epoch is selected.
 
         Returns:
             A new SacPZ instance for the response epoch active at *time*

--- a/src/pysmo/lib/io/_sacpz.py
+++ b/src/pysmo/lib/io/_sacpz.py
@@ -1,6 +1,6 @@
 """Low-level parsing of the SAC PZ (pole-zero) text format.
 
-A SAC PZ file (as produced by e.g. the EarthScope SACPZ web service) encodes
+A SAC PZ file (as produced by e.g. EarthScope's fdsnws-station service) encodes
 one instrument's analog response as poles, zeros, and a single `CONSTANT`
 (the product of the analog normalisation factor `A0` and the overall system
 sensitivity — see
@@ -117,10 +117,10 @@ def _parse_complex_block(
 def parse_sacpz(text: str) -> list[_RawSacPzResponse]:
     r"""Split SAC PZ text into a list of uninterpreted records.
 
-    A text body may contain several concatenated records (the EarthScope
-    SACPZ web service returns one per channel epoch when a query is not
-    pinned to a single epoch); this function returns all of them, in order
-    of appearance.
+    A text body may contain several concatenated records (EarthScope's
+    fdsnws-station service returns one per channel epoch when a query is
+    not pinned to a single epoch); this function returns all of them, in
+    order of appearance.
 
     Args:
         text: SAC PZ text body, containing one or more records.

--- a/src/pysmo/tools/signal/_response.py
+++ b/src/pysmo/tools/signal/_response.py
@@ -109,7 +109,7 @@ def remove_response[T: Seismogram](
 
     For a [`SacPZ`][pysmo.classes.SacPZ]-derived `response`, this path's output
     is typically *not* in the units `input_units` declares: by SAC convention
-    (followed by e.g. the EarthScope SACPZ web service and `rdseed -p`), the
+    (followed by e.g. EarthScope's fdsnws-station service and `rdseed -p`), the
     `SENSITIVITY` header (`reference_sensitivity`) stays in the sensor's
     native units (e.g. `M/S**2` for an accelerometer), while
     `poles`/`zeros`/`overall_sensitivity` — and therefore `input_units`, and

--- a/src/pysmo/tools/web.py
+++ b/src/pysmo/tools/web.py
@@ -15,7 +15,6 @@ Predicted arrival times, used to window these fetches, are computed
 locally by [`pysmo.tools.traveltime`][] with no web service involved.
 """
 
-import warnings
 from dataclasses import dataclass
 from typing import Any, Literal, Self
 
@@ -49,9 +48,8 @@ type QuakeMLOrderBy = Literal["time", "time-asc", "magnitude", "magnitude-asc"]
 class _ServiceDefaults:
     """Default web-service endpoints and HTTP retry policy.
 
-    Mostly EarthScope's (`fdsnws-station`/`-dataselect`, `irisws-sacpz`);
-    `event_url` is USGS because EarthScope retired its `fdsnws-event`
-    service.
+    Mostly EarthScope's (`fdsnws-station`/`-dataselect`); `event_url` is
+    USGS because EarthScope retired its `fdsnws-event` service.
     """
 
     def __new__(cls) -> Self:
@@ -62,7 +60,6 @@ class _ServiceDefaults:
 
     station_url: str = "https://service.earthscope.org/fdsnws/station/1/query"
     event_url: str = "https://earthquake.usgs.gov/fdsnws/event/1/query"
-    sacpz_url: str = "https://service.earthscope.org/irisws/sacpz/1/query"
     dataselect_url: str = "https://service.earthscope.org/fdsnws/dataselect/1/query"
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
     request_retries: int = DEFAULT_REQUEST_RETRIES
@@ -126,6 +123,9 @@ def fetch_stationxml(*, station: Station) -> bytes:
 def fetch_sacpz(*, station: Station, time: pd.Timestamp | None = None) -> str:
     """Fetch raw SAC PZ response metadata text for a station/channel.
 
+    Fetched from `fdsnws-station` with `level=response&format=sacpz`,
+    EarthScope's designated replacement for the `irisws-sacpz` service.
+
     A lower-level counterpart to
     [`SacPZ.fetch`][pysmo.classes.SacPZ.fetch]: returns the response
     metadata unparsed and uninterpreted. Save it to disk to defer parsing
@@ -138,12 +138,8 @@ def fetch_sacpz(*, station: Station, time: pd.Timestamp | None = None) -> str:
             protocol. Provides the network, station code, location, and
             channel for the request.
         time: Timestamp used to select the response epoch server-side, so
-            exactly one epoch is returned. If `None`, the SACPZ web
-            service defaults to the currently-open epoch. Truncated to
-            whole seconds before the request is sent — the web service
-            returns an HTTP error for a `time` with sub-second precision
-            (confirmed against the live service, not documented by
-            EarthScope) — with a `UserWarning` if that changes the value.
+            exactly one epoch is returned. If `None`, the web service
+            defaults to the currently-open epoch.
 
     Returns:
         Raw SAC PZ text.
@@ -168,25 +164,18 @@ def fetch_sacpz(*, station: Station, time: pd.Timestamp | None = None) -> str:
         ```
         <!-- skip: end -->
     """
-    params = {
+    params: dict[str, Any] = {
         "net": station.network,
         "sta": station.name,
         "loc": station.location,
         "cha": station.channel,
+        "level": "response",
+        "format": "sacpz",
     }
     if time is not None:
-        time = convert_to_utc_timestamp(time)
-        floored = time.floor("s")
-        if floored != time:
-            warnings.warn(
-                "SACPZ web service rejects sub-second precision in "
-                + f"'time'; truncating {time} to {floored}.",
-                stacklevel=2,
-            )
-            time = floored
-        params["time"] = time.isoformat()
+        params["time"] = convert_to_utc_timestamp(time).isoformat()
     return http_get(
-        _ServiceDefaults.sacpz_url,
+        _ServiceDefaults.station_url,
         params,
         timeout_seconds=_ServiceDefaults.timeout_seconds,
         request_retries=_ServiceDefaults.request_retries,

--- a/tests/tools/test_web.py
+++ b/tests/tools/test_web.py
@@ -102,36 +102,37 @@ class TestFetchSacpz:
     def test_returns_raw_text(
         self, monkeypatch: pytest.MonkeyPatch, station: MiniStation
     ) -> None:
-        fake = FakeHttpGet({"sacpz": SACPZ_SINGLE.encode("ascii")})
+        fake = FakeHttpGet({"station": SACPZ_SINGLE.encode("ascii")})
         monkeypatch.setattr("pysmo.tools.web.http_get", fake)
 
         text = fetch_sacpz(station=station)
 
         assert text == SACPZ_SINGLE
         (url, fields) = fake.calls[0]
+        assert "fdsnws/station" in url
         assert fields["net"] == "IU"
         assert fields["sta"] == "ANMO"
         assert fields["loc"] == "00"
         assert fields["cha"] == "LHZ"
-        assert "level" not in fields
+        assert fields["level"] == "response"
+        assert fields["format"] == "sacpz"
 
     def test_round_trip_with_sacpz_from_text(
         self, monkeypatch: pytest.MonkeyPatch, station: MiniStation
     ) -> None:
-        fake = FakeHttpGet({"sacpz": SACPZ_SINGLE.encode("ascii")})
+        fake = FakeHttpGet({"station": SACPZ_SINGLE.encode("ascii")})
         monkeypatch.setattr("pysmo.tools.web.http_get", fake)
 
         text = fetch_sacpz(station=station)
         response = SacPZ.from_text(text)
 
-        assert isinstance(response, Response)
         assert response.network == "IU"
         assert response.station == "ANMO"
 
     def test_bulk_fixture_round_trip_with_all_from_text(
         self, monkeypatch: pytest.MonkeyPatch, station: MiniStation
     ) -> None:
-        fake = FakeHttpGet({"sacpz": SACPZ_BULK.encode("ascii")})
+        fake = FakeHttpGet({"station": SACPZ_BULK.encode("ascii")})
         monkeypatch.setattr("pysmo.tools.web.http_get", fake)
 
         text = fetch_sacpz(station=station)
@@ -139,32 +140,16 @@ class TestFetchSacpz:
 
         assert len(responses) == 9
 
-    def test_sub_second_time_truncated_with_warning(
+    def test_sub_second_time_passed_through(
         self, monkeypatch: pytest.MonkeyPatch, station: MiniStation
     ) -> None:
-        fake = FakeHttpGet({"sacpz": SACPZ_SINGLE.encode("ascii")})
+        fake = FakeHttpGet({"station": SACPZ_SINGLE.encode("ascii")})
         monkeypatch.setattr("pysmo.tools.web.http_get", fake)
 
-        with pytest.warns(UserWarning, match="sub-second precision"):
-            fetch_sacpz(station=station, time=pd.Timestamp("2010-02-27T06:37:51.0936Z"))
+        fetch_sacpz(station=station, time=pd.Timestamp("2010-02-27T06:37:51.0936Z"))
 
         (_, fields) = fake.calls[0]
-        assert fields["time"] == "2010-02-27T06:37:51+00:00"
-
-    def test_whole_second_time_not_truncated_no_warning(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        station: MiniStation,
-        recwarn: pytest.WarningsRecorder,
-    ) -> None:
-        fake = FakeHttpGet({"sacpz": SACPZ_SINGLE.encode("ascii")})
-        monkeypatch.setattr("pysmo.tools.web.http_get", fake)
-
-        fetch_sacpz(station=station, time=pd.Timestamp("2010-02-27T06:37:51Z"))
-
-        assert len(recwarn) == 0
-        (_, fields) = fake.calls[0]
-        assert fields["time"] == "2010-02-27T06:37:51+00:00"
+        assert fields["time"] == "2010-02-27T06:37:51.093600+00:00"
 
 
 class TestFetchSac:

--- a/uv.lock
+++ b/uv.lock
@@ -1274,6 +1274,7 @@ test = [
     { name = "pytest-depends" },
     { name = "pytest-mpl" },
     { name = "pytest-mypy" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-sugar" },
     { name = "ruff" },
     { name = "sybil", extra = ["pytest"] },
@@ -1317,6 +1318,7 @@ test = [
     { name = "pytest-depends", specifier = ">=1.0.1" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
     { name = "pytest-mypy", specifier = ">=1.0.1" },
+    { name = "pytest-rerunfailures", specifier = ">=16.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "ruff", specifier = ">=0.11.13" },
     { name = "sybil", extras = ["pytest"], specifier = ">=9.2.0" },
@@ -1397,6 +1399,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b0/50/3ce149b469e27848c1dc354553b17774f9dde0140625f5a4130bd21e1052/pytest_mypy-1.0.1.tar.gz", hash = "sha256:3f5fcaff75c80dccc6b68cf5ecc28e1bbe71e95309469eb7a28bf408ce55c074", size = 15975, upload-time = "2025-04-02T19:31:16.151Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/93/25ed3c02e15c4ef1b04cbda7c708ffc5da755986aaacfb48db1f9e84a996/pytest_mypy-1.0.1-py3-none-any.whl", hash = "sha256:ad7133c9b92c802e032f2596590ebede7eea7c418e61d60d5cdd571b55c72056", size = 8701, upload-time = "2025-04-02T19:31:14.914Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/63/0114e45d4b2fcd5f6297dac655c067b47de28be4d33e088f200f0f2c4c28/pytest_rerunfailures-16.6.tar.gz", hash = "sha256:29dbfee46f542073c888e0ed4e81c51e15b9096f49a299eb1a759629c601684a", size = 42806, upload-time = "2026-08-17T07:11:00.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5e/1e994889673d7a0da11651f17ef789b6c83bfe349f29f871873dd3802445/pytest_rerunfailures-16.6-py3-none-any.whl", hash = "sha256:6af2d1ebd6e5cb79666ac408942cd6a0672a49fefd8523664770718560795e13", size = 19137, upload-time = "2026-08-17T07:10:59.121Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
EarthScope's irisws-sacpz endpoint now returns its HTML doc page for every request. fdsnws-station with level=response&format=sacpz is the designated replacement and accepts sub-second `time` precision, so fetch_sacpz no longer floors it or warns.

Add a weekly workflow running the live (--run-real-web-requests) tests to catch this kind of upstream drift; on failure it opens an "upstream-drift" issue, and transient network errors are retried via pytest-rerunfailures.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--307.org.readthedocs.build/en/307/

<!-- readthedocs-preview pysmo end -->