### PR TITLE
refactor!: drop @runtime_checkable from protocol types

### DIFF
--- a/docs/usage/external-classes.md
+++ b/docs/usage/external-classes.md
@@ -33,15 +33,21 @@ with).
 ### Yes
 
 If the external class has the same attributes (name and type) as a given pysmo
-type, then it should work out-of-the-box. You can verify this using
-[`isinstance`][]:
+type, then it works out-of-the-box. To check, pass an instance to a function
+annotated with the pysmo type and run [mypy](https://mypy.readthedocs.io) (or
+watch your editor): a matching class is accepted, and a near-miss is flagged at
+the attribute that doesn't line up.
 
 <!-- skip: start -->
 
 ```python
 >>> from pysmo import Location
->>> isinstance(my_external_object, Location)
-True
+>>>
+>>> def describe(location: Location) -> str:
+...     return f"{location.latitude}, {location.longitude}"
+...
+>>> describe(my_external_object)  # mypy accepts this call if the class matches
+'41.9, -87.6'
 >>>
 ```
 
@@ -50,6 +56,12 @@ True
 This is most likely to happen with simpler types like
 [`Location`][pysmo.Location], which only requires `latitude` and `longitude`
 attributes of type [`float`][].
+
+Pysmo deliberately does *not* expect you to gate this with a runtime check, such
+as [`isinstance`][] against the protocol (pysmo's protocols are not
+`runtime_checkable`). Conformance is something the type checker proves, so the
+workflow is to react to what mypy or your editor reports, before the code ever
+runs.
 
 ### Yes, with a tiny bit of work
 
@@ -162,7 +174,7 @@ class MyExtendedClass(ExternalClass):
         self.event_location = EventLocation(parent=self)
 ```
 
-Inheriting from `ExternalClass` isn't required here — composition (holding the
+Inheriting from `ExternalClass` isn't required here. Composition (holding the
 external object as an attribute rather than subclassing it) works just as well:
 
 <!-- skip: next -->
@@ -176,7 +188,7 @@ class MyExtendedClass:
 ```
 
 Composition is the better choice whenever `ExternalClass` has a large surface
-you don't want to expose wholesale on `MyExtendedClass` — see the
+you don't want to expose wholesale on `MyExtendedClass`. See the
 [`SAC`][pysmo.classes.SAC] example below, which does exactly this.
 
 ## Examples
@@ -188,12 +200,12 @@ class. The underlying [`SacIO`][pysmo.lib.io.SacIO] class manages file I/O and
 provides access to all SAC header fields using their original names (`stla`,
 `evla`, `b`, etc.). These names do not match pysmo types, and several types
 (station location, event location, seismogram data) coexist within a single
-object — and exposing all ~99 raw headers alongside the curated attributes
+object. Exposing all ~99 raw headers alongside the curated attributes
 invites name clashes and reference-time mixups: raw `t0` (a `float`, an offset
 in seconds from *that file's own* reference time) would sit right next to
-`SAC.timestamps.t0` (a [`pandas.Timestamp`][] in UTC, described below — a fixed
+`SAC.timestamps.t0` (a [`pandas.Timestamp`][] in UTC, described below: a fixed
 point in calendar time, not an offset from another point) under the same name
-but with incompatible types and semantics — mixing the two, or comparing `t0`
+but with incompatible types and semantics. Mixing the two, or comparing `t0`
 across two files with different reference times, produces a wrong answer with no
 indication anything went wrong.
 
@@ -213,15 +225,21 @@ curated attributes. Typically, it is much less work to adapt an existing class
 than what went into building it in the first place:
 
 ```python
->>> from pysmo import Seismogram, Station, Event
+>>> from pysmo import Event, Seismogram, Station
 >>> from pysmo.classes import SAC
+>>>
+>>> def begin_year(seismogram: Seismogram) -> int:
+...     return seismogram.begin_time.year
+...
+>>> def station_id(station: Station) -> str:
+...     return f"{station.network}.{station.name}"
+...
+>>> def origin_year(event: Event) -> int:
+...     return event.time.year
+...
 >>> sac = SAC.from_file("example.sac")
->>> isinstance(sac.seismogram, Seismogram)
-True
->>> isinstance(sac.station, Station)
-True
->>> isinstance(sac.event, Event)
-True
+>>> begin_year(sac.seismogram), station_id(sac.station), origin_year(sac.event)
+(2010, 'IU.ANMO', 2010)
 >>>
 ```
 
@@ -230,7 +248,7 @@ For more details, see the [`SAC`][pysmo.classes.SAC] API documentation.
 ### ObsPy's `Trace`
 
 The [`SAC`][pysmo.classes.SAC] example above is pysmo's own code adapting
-pysmo's own [`SacIO`][pysmo.lib.io.SacIO] class — useful to see the pattern used
+pysmo's own [`SacIO`][pysmo.lib.io.SacIO] class, useful to see the pattern used
 for real, but not literally an external class. A more realistic case for many
 seismologists: you already have waveform data as an
 [ObsPy](https://docs.obspy.org/) `Trace` object and want to run pysmo's
@@ -241,7 +259,7 @@ functions and tools on it without converting your whole workflow.
 [`pandas.Timedelta`][]), so this needs the "attribute name and format differ"
 treatment from above, not the free out-of-the-box case: the adapter needs
 properties that convert between the two, not simple aliases. (`end_time` isn't
-read from `Trace.stats.endtime` at all — it's derived from `begin_time` and
+read from `Trace.stats.endtime` at all; it's derived from `begin_time` and
 `delta` instead, the same way [`Seismogram`][pysmo.Seismogram]'s `end_time` is
 meant to be computed.)
 
@@ -254,7 +272,6 @@ meant to be computed.)
 ```python
 >>> import numpy as np
 >>> from obspy import Trace
->>> from pysmo import Seismogram
 >>> from pysmo.functions import detrend
 >>> trace = Trace(
 ...     data=np.array([1.0, 2.0, 3.0, 2.0, 1.0]),
@@ -268,9 +285,7 @@ meant to be computed.)
 ...     },
 ... )
 >>> trace_seis = TraceSeismogram(trace)
->>> isinstance(trace_seis, Seismogram)
-True
->>> detrend(trace_seis)
+>>> detrend(trace_seis)  # detrend takes a Seismogram; mypy accepts trace_seis
 >>> trace.data
 array([...])
 >>>
@@ -280,9 +295,9 @@ array([...])
 
 With the setters in place, every [`pysmo.functions`][] and [`pysmo.tools`][]
 call that takes a [`Seismogram`][pysmo.Seismogram] works on `trace_seis`
-directly — including the ones that mutate in place, like `detrend` above. Note
-what this adapter does *not* attempt: `Trace.stats` has no latitude/longitude —
-that lives in ObsPy's separate `Inventory` hierarchy, not on `Trace` itself — so
+directly, including the ones that mutate in place, like `detrend` above. Note
+what this adapter does *not* attempt: `Trace.stats` has no latitude/longitude
+(that lives in ObsPy's separate `Inventory` hierarchy, not on `Trace` itself), so
 `TraceSeismogram` only ever satisfies [`Seismogram`][pysmo.Seismogram], never
 [`Station`][pysmo.Station]. Supply station/event metadata separately, the same
 way [`GeoCsvSeismogram.fetch()`][pysmo.classes.GeoCsvSeismogram.fetch] does.
@@ -295,7 +310,7 @@ way [`GeoCsvSeismogram.fetch()`][pysmo.classes.GeoCsvSeismogram.fetch] does.
     (`detrend(seismogram)`). That difference isn't incidental. A method bound to
     `Trace` only ever works on a `Trace` (or a subclass of it). A function written
     against the [`Seismogram`][pysmo.Seismogram] protocol works on anything that
-    satisfies it — `TraceSeismogram` here,
+    satisfies it: `TraceSeismogram` here,
     [`SacSeismogram`][pysmo.classes.SacSeismogram], a [mini class](mini-classes.md),
     or any bespoke class you write yourself. That's why the exact same
     [`detrend`][pysmo.functions.detrend] call works unchanged on the
@@ -303,8 +318,44 @@ way [`GeoCsvSeismogram.fetch()`][pysmo.classes.GeoCsvSeismogram.fetch] does.
     dispatch logic anywhere to make that happen. Targeting the protocol rather than
     one specific class is what makes every function in
     [`pysmo.functions`][]/[`pysmo.tools`][] reusable this way. And it isn't limited
-    to pysmo's own functions — any function you write yourself against
+    to pysmo's own functions; any function you write yourself against
     [`Seismogram`][pysmo.Seismogram] gets the same property for free.
+
+## When you genuinely need a runtime check
+
+Everything above is about *conformance*: does this class speak a pysmo type?
+That is a question for the type checker, not for [`isinstance`][]. Occasionally
+you have a different question. At runtime you are holding a mix of objects and
+need to treat two shapes differently. For example, some of your station objects
+carry coordinates (they satisfy [`Station`][pysmo.Station]) and some are
+NSLC-only (they satisfy [`StationCode`][pysmo.StationCode] but not
+[`Station`][pysmo.Station], as a seismogram read straight from miniSEED does),
+and the code needs to branch on which it has.
+
+Write that branch as a [`TypeIs`][typing.TypeIs] guard. It narrows the type for
+the type checker in both branches, and names exactly what is being checked:
+
+```python
+>>> from typing import TypeIs
+>>> from pysmo import MiniStation, MiniStationCode, Station, StationCode
+>>>
+>>> def has_location(sta: StationCode) -> TypeIs[Station]:
+...     return hasattr(sta, "latitude") and hasattr(sta, "longitude")
+...
+>>> stations: list[StationCode] = [
+...     MiniStation(
+...         name="ANMO", network="IU", location="00", channel="BHZ",
+...         latitude=34.95, longitude=-106.46,
+...     ),
+...     MiniStationCode(name="COLA", network="IU", location="00", channel="BHZ"),
+... ]
+>>> [sta.name for sta in stations if has_location(sta)]
+['ANMO']
+>>>
+```
+
+This is for runtime dispatch over mixed data, **not** for checking whether a
+class conforms to a protocol. That stays a type-checker job.
 
 ## Beyond adapting existing classes
 
@@ -314,7 +365,7 @@ type actually is.
 
 You've already built this twice in this chapter, in two different shapes,
 without necessarily naming what it was. The helper-class approach builds a
-narrow view as a separate object that reads from — and writes back to — a richer
+narrow view as a separate object that reads from, and writes back to, a richer
 parent; [`SacSeismogram`][pysmo.classes.SacSeismogram] is a real example of
 exactly this: [`SAC`][pysmo.classes.SAC] carries the full complexity of a SAC
 file's header, [`SacSeismogram`][pysmo.classes.SacSeismogram] exposes only what
@@ -322,21 +373,21 @@ file's header, [`SacSeismogram`][pysmo.classes.SacSeismogram] exposes only what
 need a separate object: a single bespoke class can carry its own extra
 attributes directly, alongside the ones a protocol requires, and still be handed
 to any function expecting that protocol unchanged. Either way, the "rich" and
-"narrow" views aren't two objects with data copied between them — they're two
+"narrow" views aren't two objects with data copied between them; they're two
 readings of the same one.
 
 That's actually a general pattern, not something specific to these two examples.
 The same object can be two different things at once, depending on who's looking
 at it. To the code that owns it, a seismogram can carry arbitrarily rich,
-problem-specific state — processing history, quality flags, picks, provenance,
+problem-specific state: processing history, quality flags, picks, provenance,
 whatever the task at hand actually needs. To a function written against
 [`Seismogram`][pysmo.Seismogram], that same object is just `begin_time`, `data`,
-`delta`, nothing more. Both are true at the same time, of the same instance —
+`delta`, nothing more. Both are true at the same time, of the same instance:
 the type doesn't strip anything away, it just describes which part of the object
 a given piece of code has committed to relying on.
 
 The narrow view is the more interesting half of that pair. A type like
-[`Seismogram`][pysmo.Seismogram] isn't really a Python feature — it's a minimal
+[`Seismogram`][pysmo.Seismogram] isn't really a Python feature; it's a minimal
 specification of what a seismogram fundamentally needs to be, arrived at by
 asking what processing functions actually require rather than what any one class
 happens to expose (see
@@ -348,13 +399,13 @@ Fortran, a database schema, or a paragraph of prose. It doesn't depend on
 Python, or on pysmo, to remain true.
 
 That distinction matters over a project's lifetime. Libraries and file formats
-change — sometimes for good reasons, sometimes just because tooling fashions
-shift — and code written directly against one specific class inherits that
+change (sometimes for good reasons, sometimes just because tooling fashions
+shift), and code written directly against one specific class inherits that
 churn. Code written against a well-considered, minimal interface mostly doesn't:
 only the adaptation layer at the boundary needs to change, not the logic behind
-it. The same holds on a smaller scale too — say you move a slow step like
+it. The same holds on a smaller scale too. Say you move a slow step like
 [`mccc`][pysmo.tools.signal.mccc] from Python to a compiled language for speed.
-The hard part of a move like that is never translating syntax — it's figuring
+The hard part of a move like that is never translating syntax; it's figuring
 out what the actual minimal data model needs to be. If that work is already
 done, captured as a small, deliberate interface rather than smeared across
 whatever attributes a particular class happened to expose, the move means
@@ -364,13 +415,13 @@ re-deriving the whole data model from scratch.
 It isn't only external change that's unpredictable, either. You rarely know in
 advance how complex the class supporting a particular problem will need to
 become. A bespoke class doesn't have to mean a dataclass with a few extra
-attributes — that's the simplest case, not the only one. What starts that way
+attributes; that's the simplest case, not the only one. What starts that way
 can, as a project's real requirements surface, turn into something far more
-involved. [AIMBAT](https://github.com/pysmo/aimbat) — an arrival-time picking
-package built on pysmo — shows both ends of that range. Its first version had
+involved. [AIMBAT](https://github.com/pysmo/aimbat) (an arrival-time picking
+package built on pysmo) shows both ends of that range. Its first version had
 nowhere else to put processing state, so it stored things like filter parameters
-directly in SAC's generic `user6`/`user7`/`kuser1`/`kuser2` header fields —
-fields with no defined meaning of their own, repurposed because nothing better
+directly in SAC's generic `user6`/`user7`/`kuser1`/`kuser2` header fields, which
+have no defined meaning of their own and were repurposed because nothing better
 was available. (It's also why old AIMBAT-processed SAC files can have
 oddly-populated header fields that are confusing to decode later, if you ever
 come across one.) Current AIMBAT solves the same problem properly instead: its
@@ -379,10 +430,10 @@ stored as ordinary table columns and `data` fetched from a separate table only
 when it's actually needed. That split pays off concretely too: changing a pick
 or a sampling interval is a small database update, not a read of the whole
 waveform file. Do the same thing with a SAC file being read directly, and
-there's no such distinction available — updating one value means touching the
+there's no such distinction available: updating one value means touching the
 entire seismogram. None of that is something you can plan for up front, and it
 doesn't need to be. The protocol boundary doesn't ask the rich side to stay
-simple, or to stay anything in particular — only that
+simple, or to stay anything in particular, only that
 [`begin_time`][pysmo.Seismogram.begin_time], [`data`][pysmo.Seismogram.data],
 and [`delta`][pysmo.Seismogram.delta] keep meaning what they always meant. The
 processing logic on the other side of that boundary never has to change, no

--- a/src/pysmo/_types/event.py
+++ b/src/pysmo/_types/event.py
@@ -1,4 +1,4 @@
-from typing import Protocol, runtime_checkable
+from typing import Protocol
 
 import pandas as pd
 from attrs import define, field, setters, validators
@@ -11,7 +11,6 @@ from .location_with_depth import LocationWithDepth
 __all__ = ["Event", "MiniEvent"]
 
 
-@runtime_checkable
 class Event(LocationWithDepth, Protocol):
     """Protocol class to define the `Event` type."""
 
@@ -25,17 +24,11 @@ class MiniEvent:
 
     Examples:
         ```python
-        >>> from pysmo import MiniEvent, Event, LocationWithDepth, Location
+        >>> from pysmo import MiniEvent
         >>> import pandas as pd
         >>> from datetime import timezone
         >>> now = pd.Timestamp.now(timezone.utc)
         >>> event = MiniEvent(latitude=-24.68, longitude=-26.73, depth=15234.0, time=now)
-        >>> isinstance(event, Event)
-        True
-        >>> isinstance(event, Location)
-        True
-        >>> isinstance(event, LocationWithDepth)
-        True
         >>>
         ```
     """

--- a/src/pysmo/_types/location.py
+++ b/src/pysmo/_types/location.py
@@ -1,4 +1,4 @@
-from typing import Protocol, runtime_checkable
+from typing import Protocol
 
 from attrs import define, field, setters, validators
 
@@ -8,7 +8,6 @@ __all__ = ["Location", "MiniLocation"]
 # --8<-- [start:location-protocol]
 
 
-@runtime_checkable
 class Location(Protocol):
     """Protocol class to define the `Location` type."""
 
@@ -30,10 +29,8 @@ class MiniLocation:
 
     Examples:
         ```python
-        >>> from pysmo import MiniLocation, Location
+        >>> from pysmo import MiniLocation
         >>> location = MiniLocation(latitude=41.8781, longitude=-87.6298)
-        >>> isinstance(location, Location)
-        True
         >>>
         ```
     """

--- a/src/pysmo/_types/location_with_depth.py
+++ b/src/pysmo/_types/location_with_depth.py
@@ -1,4 +1,4 @@
-from typing import Protocol, runtime_checkable
+from typing import Protocol
 
 from attrs import define, field, setters, validators
 
@@ -7,7 +7,6 @@ from .location import Location
 __all__ = ["LocationWithDepth", "MiniLocationWithDepth"]
 
 
-@runtime_checkable
 class LocationWithDepth(Location, Protocol):
     """Protocol class to define the `LocationWithDepth` type."""
 
@@ -21,12 +20,8 @@ class MiniLocationWithDepth:
 
     Examples:
         ```python
-        >>> from pysmo import MiniLocationWithDepth, LocationWithDepth, Location
+        >>> from pysmo import MiniLocationWithDepth
         >>> hypo = MiniLocationWithDepth(latitude=-24.68, longitude=-26.73, depth=15234.0)
-        >>> isinstance(hypo, LocationWithDepth)
-        True
-        >>> isinstance(hypo, Location)
-        True
         >>>
         ```
     """

--- a/src/pysmo/_types/response.py
+++ b/src/pysmo/_types/response.py
@@ -1,4 +1,4 @@
-from typing import Protocol, runtime_checkable
+from typing import Protocol
 
 from attrs import define, field, setters, validators
 
@@ -37,7 +37,6 @@ def _convert_strict_int(value: int) -> int:
     return int(as_float)
 
 
-@runtime_checkable
 class Response(Protocol):
     """Protocol class to define the `Response` type.
 
@@ -98,7 +97,6 @@ class Response(Protocol):
     """
 
 
-@runtime_checkable
 class ResponseStage(Protocol):
     """Protocol class to define one digital (FIR/IIR) decimation stage."""
 
@@ -128,7 +126,6 @@ class ResponseStage(Protocol):
     coefficient-derived transfer function unchanged."""
 
 
-@runtime_checkable
 class StagedResponse(Response, Protocol):
     """Protocol class to define a `Response` with digital decimation stages.
 
@@ -147,15 +144,13 @@ class MiniResponse:
 
     Examples:
         ```python
-        >>> from pysmo import MiniResponse, Response
+        >>> from pysmo import MiniResponse
         >>> response = MiniResponse(
         ...     poles=[-0.037 + 0.037j, -0.037 - 0.037j],
         ...     zeros=[0j, 0j],
         ...     overall_sensitivity=3.4e9,
         ...     input_units="M/S",
         ... )
-        >>> isinstance(response, Response)
-        True
         >>>
         ```
     """
@@ -218,14 +213,12 @@ class MiniResponseStage:
 
     Examples:
         ```python
-        >>> from pysmo import MiniResponseStage, ResponseStage
+        >>> from pysmo import MiniResponseStage
         >>> stage = MiniResponseStage(
         ...     input_sample_rate=40.0,
         ...     decimation_factor=1,
         ...     numerator=[0.5, 0.5],
         ... )
-        >>> isinstance(stage, ResponseStage)
-        True
         >>> stage.denominator
         [1.0]
         >>>
@@ -292,17 +285,13 @@ class MiniStagedResponse(MiniResponse):
 
     Examples:
         ```python
-        >>> from pysmo import MiniStagedResponse, StagedResponse, Response
+        >>> from pysmo import MiniStagedResponse
         >>> response = MiniStagedResponse(
         ...     poles=[-0.037 + 0.037j, -0.037 - 0.037j],
         ...     zeros=[0j, 0j],
         ...     overall_sensitivity=3.4e9,
         ...     input_units="M/S",
         ... )
-        >>> isinstance(response, StagedResponse)
-        True
-        >>> isinstance(response, Response)
-        True
         >>>
         ```
     """

--- a/src/pysmo/_types/seismogram.py
+++ b/src/pysmo/_types/seismogram.py
@@ -1,4 +1,4 @@
-from typing import Protocol, runtime_checkable
+from typing import Protocol
 
 import numpy as np
 import numpy.typing as npt
@@ -19,7 +19,6 @@ __all__ = ["MiniSeismogram", "Seismogram"]
 # --8<-- [start:seismogram-protocol]
 
 
-@runtime_checkable
 class Seismogram(Protocol):
     """Protocol class to define the `Seismogram` type.
 
@@ -89,15 +88,13 @@ class MiniSeismogram(SeismogramEndtimeMixin):
 
     Examples:
         ```python
-        >>> from pysmo import MiniSeismogram, Seismogram
+        >>> from pysmo import MiniSeismogram
         >>> import pandas as pd
         >>> from datetime import timezone
         >>> import numpy as np
         >>> now = pd.Timestamp.now(timezone.utc)
         >>> delta = pd.Timedelta(seconds=0.1)
         >>> seismogram = MiniSeismogram(begin_time=now, delta=delta, data=np.random.rand(100))
-        >>> isinstance(seismogram, Seismogram)
-        True
         >>>
         ```
     """

--- a/src/pysmo/_types/station.py
+++ b/src/pysmo/_types/station.py
@@ -1,4 +1,4 @@
-from typing import Protocol, runtime_checkable
+from typing import Protocol
 
 from attrs import converters, define, field, setters, validators
 
@@ -9,7 +9,6 @@ __all__ = ["MiniStation", "MiniStationCode", "Station", "StationCode"]
 # --8<-- [start:station-protocol]
 
 
-@runtime_checkable
 class StationCode(Protocol):
     """Protocol class to define the `StationCode` type.
 
@@ -48,7 +47,6 @@ class StationCode(Protocol):
     """
 
 
-@runtime_checkable
 class Station(Location, StationCode, Protocol):
     """Protocol class to define the `Station` type."""
 
@@ -69,10 +67,8 @@ class MiniStationCode:
 
     Examples:
         ```python
-        >>> from pysmo import MiniStationCode, StationCode
+        >>> from pysmo import MiniStationCode
         >>> code = MiniStationCode(name="CACB", network="BL", channel="BHZ", location="00")
-        >>> isinstance(code, StationCode)
-        True
         >>>
         ```
     """
@@ -122,12 +118,8 @@ class MiniStation:
 
     Examples:
         ```python
-        >>> from pysmo import MiniStation, Station, Location
+        >>> from pysmo import MiniStation
         >>> station = MiniStation(latitude=-21.680301, longitude=-46.732601, name="CACB", network="BL", channel="BHZ", location="00")
-        >>> isinstance(station, Station)
-        True
-        >>> isinstance(station, Location)
-        True
         >>>
         ```
     """

--- a/src/pysmo/classes/_geocsv.py
+++ b/src/pysmo/classes/_geocsv.py
@@ -46,7 +46,6 @@ class GeoCsvSeismogram(SeismogramEndtimeMixin):
 
     Examples:
         ```python
-        >>> from pysmo import Seismogram
         >>> from pysmo.classes import GeoCsvSeismogram
         >>> text = '''\
         ... # dataset: GeoCSV 2.0
@@ -62,8 +61,6 @@ class GeoCsvSeismogram(SeismogramEndtimeMixin):
         ... 2010-02-27T06:30:01Z, -47298
         ... 2010-02-27T06:30:02Z, -47299'''
         >>> seismogram = GeoCsvSeismogram.from_text(text)
-        >>> isinstance(seismogram, Seismogram)
-        True
         >>> seismogram.sourceid
         'IU_ANMO_00_LHZ'
         >>> seismogram.data

--- a/src/pysmo/classes/_mseed.py
+++ b/src/pysmo/classes/_mseed.py
@@ -70,15 +70,8 @@ class MSeed(SeismogramEndtimeMixin):
 
     Examples:
         ```python
-        >>> from pysmo import Seismogram, Station, StationCode
         >>> from pysmo.classes import MSeed
         >>> seismogram = MSeed.from_file("example.mseed")
-        >>> isinstance(seismogram, Seismogram)
-        True
-        >>> isinstance(seismogram, StationCode)
-        True
-        >>> isinstance(seismogram, Station)
-        False
         >>> seismogram.sourceid
         'FDSN:IU_ANMO_00_B_H_Z'
         >>> seismogram.network, seismogram.name, seismogram.location, seismogram.channel

--- a/src/pysmo/classes/_quakeml.py
+++ b/src/pysmo/classes/_quakeml.py
@@ -52,7 +52,6 @@ class QuakeML:
 
     Examples:
         ```python
-        >>> from pysmo import Event, Location, LocationWithDepth
         >>> from pysmo.classes import QuakeML
         >>> xml = b'''<?xml version="1.0"?>
         ... <q:quakeml xmlns="http://quakeml.org/xmlns/bed/1.2"
@@ -75,8 +74,6 @@ class QuakeML:
         ...   </eventParameters>
         ... </q:quakeml>'''
         >>> event = QuakeML.from_bytes(xml)
-        >>> isinstance(event, Event)
-        True
         >>> event.latitude, event.longitude, event.depth
         (-36.122, -72.898, 22900.0)
         >>> event.magnitude, event.magnitude_type

--- a/src/pysmo/classes/_sac.py
+++ b/src/pysmo/classes/_sac.py
@@ -154,15 +154,19 @@ class SacSeismogram(_SacNested, SeismogramEndtimeMixin):
     new [`SAC`][pysmo.classes.SAC] instance.
 
     Examples:
-        Checking if a SacSeismogram matches the pysmo
+        A SacSeismogram can be passed to any function that expects the pysmo
         [`Seismogram`][pysmo.Seismogram] type:
 
         ```python
         >>> from pysmo import Seismogram
         >>> from pysmo.classes import SAC
+        >>>
+        >>> def begin_time_isoformat(seismogram: Seismogram) -> str:
+        ...     return seismogram.begin_time.isoformat()
+        ...
         >>> sac = SAC.from_file("example.sac")
-        >>> isinstance(sac.seismogram, Seismogram)
-        True
+        >>> begin_time_isoformat(sac.seismogram)
+        '2010-02-27T06:44:06.069538+00:00'
         >>>
         ```
 
@@ -220,15 +224,19 @@ class SacStation(_SacNested):
     [`SAC`][pysmo.classes.SAC] instance.
 
     Examples:
-        Checking if a SacStation matches the pysmo
+        A SacStation can be passed to any function that expects the pysmo
         [`Station`][pysmo.Station] type:
 
         ```python
         >>> from pysmo.classes import SAC
         >>> from pysmo import Station
+        >>>
+        >>> def station_id(station: Station) -> str:
+        ...     return f"{station.network}.{station.name}"
+        ...
         >>> sac = SAC.from_file("example.sac")
-        >>> isinstance(sac.station, Station)
-        True
+        >>> station_id(sac.station)
+        'IU.ANMO'
         >>>
         ```
     """
@@ -330,15 +338,19 @@ class SacEvent(_SacNested):
     [`SAC`][pysmo.classes.SAC] instance.
 
     Examples:
-        Checking if a SacEvent matches the pysmo
+        A SacEvent can be passed to any function that expects the pysmo
         [`Event`][pysmo.Event] type:
 
         ```python
         >>> from pysmo.classes import SAC
         >>> from pysmo import Event
+        >>>
+        >>> def origin_isoformat(event: Event) -> str:
+        ...     return event.time.isoformat()
+        ...
         >>> sac = SAC.from_file("example.sac")
-        >>> isinstance(sac.event, Event)
-        True
+        >>> origin_isoformat(sac.event)
+        '2010-02-27T06:34:11.529998536+00:00'
         >>>
         ```
 
@@ -623,15 +635,20 @@ class SAC:
         types, accessible under different names:
 
         ```python
-        >>> # Import the Seismogram type to check if the nested class is compatible:
         >>> from pysmo import Seismogram
         >>>
-        >>> # First verify that a SAC instance is not a pysmo Seismogram:
-        >>> isinstance(sac, Seismogram)
-        False
-        >>> # The sac.seismogram object is, however:
-        >>> isinstance(sac.seismogram, Seismogram)
-        True
+        >>> def sample_count(seismogram: Seismogram) -> int:
+        ...     return len(seismogram.data)
+        ...
+        >>> # A bare SAC instance is not a Seismogram: a type checker rejects
+        >>> # this, and at runtime the function fails on the missing member:
+        >>> sample_count(sac)
+        Traceback (most recent call last):
+            ...
+        AttributeError: 'SAC' object has no attribute 'data'
+        >>> # The sac.seismogram helper is a Seismogram:
+        >>> sample_count(sac.seismogram)
+        57465
         >>>
         ```
 

--- a/src/pysmo/classes/_sacpz.py
+++ b/src/pysmo/classes/_sacpz.py
@@ -37,7 +37,6 @@ class SacPZ:
 
     Examples:
         ```python
-        >>> from pysmo import Response
         >>> from pysmo.classes import SacPZ
         >>> text = '''\
         ... * NETWORK   (KNETWK): IU
@@ -55,8 +54,6 @@ class SacPZ:
         ... CONSTANT 1.0e+09
         ... '''
         >>> response = SacPZ.from_text(text)
-        >>> isinstance(response, Response)
-        True
         >>> response.network, response.station
         ('IU', 'ANMO')
         >>>
@@ -152,12 +149,9 @@ class SacPZ:
 
             ```python
             >>> from pathlib import Path
-            >>> from pysmo import Response
             >>> from pysmo.classes import SacPZ
             >>> text = Path("SACPZ.IU.ANMO.00.BHZ").read_text()
             >>> response = SacPZ.from_text(text)
-            >>> isinstance(response, Response)
-            True
             >>> response.network, response.station
             ('IU', 'ANMO')
             >>>

--- a/src/pysmo/classes/_stationxml.py
+++ b/src/pysmo/classes/_stationxml.py
@@ -68,7 +68,6 @@ class StationXML:
 
     Examples:
         ```python
-        >>> from pysmo import Location, Response, Station
         >>> from pysmo.classes import StationXML
         >>> xml = b'''\
         ... <?xml version="1.0"?>
@@ -100,14 +99,10 @@ class StationXML:
         ...   </Network>
         ... </FDSNStationXML>'''
         >>> station = StationXML.from_bytes(xml)
-        >>> isinstance(station, Station)
-        True
-        >>> isinstance(station, Location)
-        True
         >>> station.network, station.name, station.channel
         ('IU', 'ANMO', 'BHZ')
-        >>> isinstance(station.response, Response)
-        True
+        >>> station.response.input_units
+        'm/s'
         >>>
         ```
     """

--- a/src/pysmo/lib/mini_utils.py
+++ b/src/pysmo/lib/mini_utils.py
@@ -1,7 +1,8 @@
 """Mini utils."""
 
+import inspect
 import types
-from typing import TypeAliasType, cast, get_args
+from typing import TypeAliasType, cast, get_args, get_protocol_members
 
 from pysmo import _BaseMini, _BaseProto
 from pysmo.tools import _ToolsMini, _ToolsProto
@@ -33,23 +34,19 @@ def _get_flattened_types(tp: object) -> tuple[type, ...]:
             return (cast(type, tp),)
 
 
-def _safe_check(obj: object, proto: type) -> bool:
-    """Safely checks isinstance/issubclass for Protocols with data members."""
-    try:
-        if isinstance(obj, type):
-            return issubclass(obj, proto)
-        return isinstance(obj, proto)
-    except TypeError:
-        # Fallback: Structural check using annotations. Merged across the
-        # whole MRO, not just target.__annotations__ (which holds only the
-        # class's own annotations) - otherwise a subclass that doesn't
-        # redeclare an inherited field would spuriously fail to match.
-        proto_anns = getattr(proto, "__annotations__", {})
-        target = obj if isinstance(obj, type) else type(obj)
-        target_anns: dict[str, object] = {}
-        for klass in reversed(target.__mro__):
-            target_anns.update(getattr(klass, "__annotations__", {}))
-        return all(key in target_anns for key in proto_anns)
+def _structural_match(obj: object, proto: type) -> bool:
+    """Whether `obj` (an instance or a class) has every member `proto` requires.
+
+    Name-based structural check — signatures and types are a type-checker
+    concern, not checked here. Uses `inspect.getattr_static`, so a member
+    defined as a property whose getter would raise still counts as present.
+    """
+    for member in get_protocol_members(proto):
+        try:
+            inspect.getattr_static(obj, member)
+        except AttributeError:
+            return False
+    return True
 
 
 def proto2mini(proto: type[_AnyProto]) -> tuple[type[_AnyMini], ...]:
@@ -135,7 +132,7 @@ def matching_pysmo_types(obj: object) -> tuple[type[_AnyProto], ...]:
     possible_protos = _get_flattened_types(_AnyProto)
 
     for proto in possible_protos:
-        if _safe_check(obj, proto):
+        if _structural_match(obj, proto):
             matches.append(cast(type[_AnyProto], proto))
 
     return tuple(matches)

--- a/src/pysmo/tools/archive.py
+++ b/src/pysmo/tools/archive.py
@@ -40,7 +40,7 @@ Examples:
     ... )
     >>> seismogram = archive(station, starttime, endtime)  # miss: fetches and stores
     >>> seismogram_again = archive(station, starttime, endtime)  # hit: no fetch
-    >>> isinstance(seismogram_again, Seismogram)
+    >>> seismogram_again.data.shape == seismogram.data.shape
     True
     >>>
     ```
@@ -53,7 +53,7 @@ import threading
 import zlib
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol
 
 import pandas as pd
 from attrs import define, field
@@ -68,7 +68,6 @@ _ENCODING_VERSION = 1
 """Raw bytes are stored zlib-compressed; bump this on any change to that encoding."""
 
 
-@runtime_checkable
 class RawFetcher(Protocol):
     """Callable `(*, station, starttime, endtime) -> bytes` returning a raw, unparsed fetch response.
 

--- a/src/pysmo/tools/iccs/_types.py
+++ b/src/pysmo/tools/iccs/_types.py
@@ -1,6 +1,6 @@
 from collections.abc import Hashable
 from enum import StrEnum, auto
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol
 
 import numpy as np
 import numpy.typing as npt
@@ -63,7 +63,6 @@ class ConvergenceMethod(StrEnum):
     change = auto()
 
 
-@runtime_checkable
 class IccsSeismogram(Seismogram, Protocol):
     """Protocol class to define the `IccsSeismogram` type.
 

--- a/src/pysmo/tools/signal/_response.py
+++ b/src/pysmo/tools/signal/_response.py
@@ -2,7 +2,7 @@
 
 import warnings
 from copy import deepcopy
-from typing import Literal, cast, overload
+from typing import Literal, TypeIs, cast, overload
 
 import numpy as np
 import numpy.typing as npt
@@ -11,6 +11,11 @@ import scipy.signal
 from pysmo import Response, Seismogram, StagedResponse
 
 __all__ = ["remove_response"]
+
+
+def _has_digital_stages(response: Response) -> TypeIs[StagedResponse]:
+    """Whether `response` carries digital decimation stages."""
+    return hasattr(response, "stages")
 
 
 def _analog_transfer_function(
@@ -384,7 +389,7 @@ def remove_response[T: Seismogram](
 
     h = _analog_transfer_function(response, freqs)
 
-    if isinstance(response, StagedResponse):
+    if _has_digital_stages(response):
         h = h * _digital_transfer_function(response, freqs)
         has_stages = bool(response.stages)
         if has_stages:

--- a/src/pysmo/tools/traveltime/_types.py
+++ b/src/pysmo/tools/traveltime/_types.py
@@ -1,7 +1,7 @@
 """Type aliases and the backend protocol shared across the travel-time tools."""
 
 from collections.abc import Mapping, Sequence
-from typing import Literal, Protocol, runtime_checkable
+from typing import Literal, Protocol
 
 import pandas as pd
 
@@ -15,7 +15,6 @@ type Phase = Literal["P", "S", "PcP", "ScS", "PcS", "ScP"]
 """A phase name the built-in solver computes."""
 
 
-@runtime_checkable
 class TravelTimeBackend(Protocol):
     """The shape of a replacement travel-time function.
 

--- a/tests/classes/mini/test_mini_event.py
+++ b/tests/classes/mini/test_mini_event.py
@@ -3,7 +3,7 @@ from datetime import UTC
 import pandas as pd
 import pytest
 
-from pysmo import Event, MiniEvent
+from pysmo import MiniEvent
 
 
 class TestMiniEvent:
@@ -23,7 +23,6 @@ class TestMiniEvent:
             latitude=latitude, longitude=longitude, depth=depth, time=time_utc
         )
         assert isinstance(minievent, MiniEvent)
-        assert isinstance(minievent, Event)
 
     @pytest.mark.depends(name="test_create_instance")
     def test_change_attributes(self) -> None:
@@ -43,8 +42,6 @@ class TestMiniEvent:
         minievent = MiniEvent(
             latitude=latitude, longitude=longitude, depth=depth, time=time
         )
-
-        assert isinstance(minievent, Event)
 
         assert minievent.depth == depth
         assert minievent.latitude == latitude

--- a/tests/classes/mini/test_mini_location.py
+++ b/tests/classes/mini/test_mini_location.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pysmo import Location, MiniLocation
+from pysmo import MiniLocation
 
 
 class TestMiniLocation:
@@ -14,7 +14,6 @@ class TestMiniLocation:
         latitude, longitude = 1.1, 2.2
         minilocation = MiniLocation(latitude=latitude, longitude=longitude)
         assert isinstance(minilocation, MiniLocation)
-        assert isinstance(minilocation, Location)
         assert minilocation.latitude == 1.1
         assert minilocation.longitude == 2.2
 

--- a/tests/classes/mini/test_mini_location_with_depth.py
+++ b/tests/classes/mini/test_mini_location_with_depth.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pysmo import LocationWithDepth, MiniLocationWithDepth
+from pysmo import MiniLocationWithDepth
 
 
 class TestMiniLocationWithDepth:
@@ -14,7 +14,6 @@ class TestMiniLocationWithDepth:
             latitude=latitude, longitude=longitude, depth=depth
         )
         assert isinstance(minihypocenter, MiniLocationWithDepth)
-        assert isinstance(minihypocenter, LocationWithDepth)
 
     @pytest.mark.depends(name="test_create_instance")
     def test_change_attributes(self) -> None:
@@ -24,8 +23,6 @@ class TestMiniLocationWithDepth:
         minihypocenter = MiniLocationWithDepth(
             latitude=latitude, longitude=longitude, depth=depth
         )
-
-        assert isinstance(minihypocenter, LocationWithDepth)
 
         assert minihypocenter.depth == depth
         assert minihypocenter.latitude == latitude

--- a/tests/classes/mini/test_mini_response.py
+++ b/tests/classes/mini/test_mini_response.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pysmo import MiniResponse, Response
+from pysmo import MiniResponse
 
 
 class TestMiniResponse:
@@ -15,7 +15,6 @@ class TestMiniResponse:
             input_units="M/S",
         )
         assert isinstance(response, MiniResponse)
-        assert isinstance(response, Response)
         assert response.poles == [-0.037 + 0.037j, -0.037 - 0.037j]
         assert response.zeros == [0j, 0j]
         assert response.overall_sensitivity == 3.4e9

--- a/tests/classes/mini/test_mini_seismogram.py
+++ b/tests/classes/mini/test_mini_seismogram.py
@@ -15,7 +15,6 @@ class TestMiniSeismogram:
 
         miniseis = MiniSeismogram()
         assert isinstance(miniseis, MiniSeismogram)
-        assert isinstance(miniseis, Seismogram)
 
     @pytest.mark.depends(name="test_create_instance")
     def test_defaults(self) -> None:

--- a/tests/classes/mini/test_mini_staged_response.py
+++ b/tests/classes/mini/test_mini_staged_response.py
@@ -1,12 +1,6 @@
 import pytest
 
-from pysmo import (
-    MiniResponseStage,
-    MiniStagedResponse,
-    Response,
-    ResponseStage,
-    StagedResponse,
-)
+from pysmo import MiniResponseStage, MiniStagedResponse
 
 
 class TestMiniResponseStage:
@@ -18,7 +12,6 @@ class TestMiniResponseStage:
             input_sample_rate=40.0, decimation_factor=1, numerator=[0.5, 0.5]
         )
         assert isinstance(stage, MiniResponseStage)
-        assert isinstance(stage, ResponseStage)
         assert stage.input_sample_rate == 40.0
         assert stage.decimation_factor == 1
         assert stage.numerator == [0.5, 0.5]
@@ -76,8 +69,6 @@ class TestMiniStagedResponse:
             ],
         )
         assert isinstance(response, MiniStagedResponse)
-        assert isinstance(response, StagedResponse)
-        assert isinstance(response, Response)
         assert len(response.stages) == 1
 
     def test_empty_stages_still_satisfies_staged_response(self) -> None:
@@ -85,8 +76,6 @@ class TestMiniStagedResponse:
             poles=[], zeros=[], overall_sensitivity=1.0, input_units="M/S"
         )
         assert response.stages == []
-        assert isinstance(response, StagedResponse)
-        assert isinstance(response, Response)
 
     def test_reference_sensitivity_inherited_from_mini_response(self) -> None:
         response = MiniStagedResponse(

--- a/tests/classes/mini/test_mini_station.py
+++ b/tests/classes/mini/test_mini_station.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pysmo import MiniStation, Station
+from pysmo import MiniStation
 
 
 class TestMiniStation:
@@ -26,7 +26,6 @@ class TestMiniStation:
             longitude=longitude,
         )
         assert isinstance(ministation, MiniStation)
-        assert isinstance(ministation, Station)
         assert ministation.name == "stat"
         assert ministation.latitude == 1.1
         assert ministation.longitude == 2.2

--- a/tests/classes/test_geocsv_seismogram.py
+++ b/tests/classes/test_geocsv_seismogram.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 
-from pysmo import MiniStation, Seismogram
+from pysmo import MiniStation
 from pysmo.classes import GeoCsvSeismogram
 
 FIXTURE = (
@@ -37,7 +37,6 @@ Time, Sample
 class TestGeoCsvSeismogram:
     def test_from_text(self) -> None:
         seismogram = GeoCsvSeismogram.from_text(TEXT)
-        assert isinstance(seismogram, Seismogram)
         assert seismogram.begin_time == pd.Timestamp("2010-02-27T06:30:00Z")
         assert seismogram.delta == pd.Timedelta(seconds=0.5)
         npt.assert_allclose(seismogram.data, [1.0, 2.0, 3.0])
@@ -126,7 +125,6 @@ class TestFetch:
             endtime=pd.Timestamp("2010-02-27T06:30:01Z"),
         )
 
-        assert isinstance(seismogram, Seismogram)
         assert seismogram.sourceid == "IU_ANMO_00_LHZ"
         npt.assert_allclose(seismogram.data, [1.0, 2.0, 3.0])
 

--- a/tests/classes/test_mseed.py
+++ b/tests/classes/test_mseed.py
@@ -8,16 +8,10 @@ import pandas as pd
 import pymseed
 import pytest
 
-from pysmo import (
-    MiniSeismogram,
-    MiniStation,
-    MiniStationCode,
-    Seismogram,
-    Station,
-    StationCode,
-)
+from pysmo import MiniSeismogram, MiniStation, MiniStationCode, Station, StationCode
 from pysmo.classes import MSeed
 from pysmo.lib.io import write_mseed
+from pysmo.lib.mini_utils import _structural_match
 
 GAP_FIXTURE = Path(__file__).parent / "assets" / "mseed_gap.mseed"
 
@@ -51,9 +45,8 @@ def make_mseed_bytes(
 class TestRead:
     def test_from_bytes(self) -> None:
         seismogram = MSeed.from_bytes(make_mseed_bytes())
-        assert isinstance(seismogram, Seismogram)
-        assert isinstance(seismogram, StationCode)
-        assert not isinstance(seismogram, Station)
+        assert _structural_match(seismogram, StationCode)
+        assert not _structural_match(seismogram, Station)
         assert seismogram.begin_time == pd.Timestamp("2010-02-27T06:30:00Z")
         assert seismogram.delta == pd.Timedelta(seconds=0.05)
         assert seismogram.sample_count == 100
@@ -164,7 +157,6 @@ class TestFetch:
             endtime=pd.Timestamp("2010-02-27T06:30:05Z"),
         )
 
-        assert isinstance(seismogram, Seismogram)
         assert seismogram.sourceid == "FDSN:IU_ANMO_00_B_H_Z"
 
         _, fields = calls[0]

--- a/tests/classes/test_quakeml_class.py
+++ b/tests/classes/test_quakeml_class.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from pysmo import Event, Location, LocationWithDepth, MiniEvent
+from pysmo import MiniEvent
 from pysmo.classes import QuakeML
 from pysmo.functions import clone_to_mini
 
@@ -40,12 +40,6 @@ def _event(public_id: str, *, extra: str = "") -> str:
 
 
 class TestConformance:
-    def test_isinstance_triple(self) -> None:
-        event = QuakeML.from_bytes(_doc(_event("smi:e/1")))
-        assert isinstance(event, Event)
-        assert isinstance(event, Location)
-        assert isinstance(event, LocationWithDepth)
-
     def test_clone_to_mini(self) -> None:
         event = QuakeML.from_bytes(_doc(_event("smi:e/1")))
         mini = clone_to_mini(MiniEvent, event)

--- a/tests/classes/test_sac.py
+++ b/tests/classes/test_sac.py
@@ -8,7 +8,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 
-from pysmo import Event, MiniStation, Seismogram, Station
+from pysmo import MiniStation
 from pysmo.classes import SAC
 from pysmo.lib.defaults import SeismogramDefaults
 from pysmo.lib.io import SacIO
@@ -37,14 +37,11 @@ class TestSAC:
     def test_create_instance(self) -> None:
         sac = SAC()
         assert isinstance(sac, SAC)
-        assert isinstance(sac.seismogram, Seismogram)
 
         # coordinates for event and station are None.
         with pytest.raises(TypeError):
-            assert isinstance(sac.station, Station)
             sac.station.latitude
         with pytest.raises(TypeError):
-            assert isinstance(sac.event, Event)
             sac.event.latitude
 
     @pytest.mark.depends(on=["test_create_instance"])
@@ -71,9 +68,6 @@ class TestSAC:
     def test_create_instance_from_file(self, sacfile: Path) -> None:
         sac = SAC.from_file(sacfile)
         assert isinstance(sac, SAC)
-        assert isinstance(sac.seismogram, Seismogram)
-        assert isinstance(sac.station, Station)
-        assert isinstance(sac.event, Event)
 
     @pytest.mark.depends(on=["test_create_instance_from_file"])
     def test_native_is_frozen(self, sacfile: Path) -> None:
@@ -126,7 +120,6 @@ class TestSAC:
     def test_sac_seismogram(self, sacfile: Path) -> None:
         sacseis = SAC.from_file(sacfile).seismogram
         sacio = SacIO.from_file(sacfile)
-        assert isinstance(sacseis, Seismogram)
         assert isinstance(sacseis.data, np.ndarray)
         assert sacseis.data.all() == sacio.data.all()
         assert list(sacseis.data[:5]) == [

--- a/tests/classes/test_sacpz_class.py
+++ b/tests/classes/test_sacpz_class.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from pysmo import MiniStation, Response
+from pysmo import MiniStation
 from pysmo.classes import SacPZ
 
 SINGLE_FIXTURE = (
@@ -35,7 +35,6 @@ CONSTANT\t1.0e+09
 class TestFromText:
     def test_real_single_record_fixture(self) -> None:
         response = SacPZ.from_text(SINGLE_FIXTURE.read_text())
-        assert isinstance(response, Response)
         assert response.network == "IU"
         assert response.station == "ANMO"
         assert response.location == "00"
@@ -68,7 +67,6 @@ class TestAllFromText:
         responses = SacPZ.all_from_text(BULK_FIXTURE.read_text())
         assert len(responses) == 9
         for response in responses:
-            assert isinstance(response, Response)
             assert response.network == "IU"
             assert response.station == "ANMO"
         for previous, current in zip(responses, responses[1:]):
@@ -107,7 +105,6 @@ class TestFetch:
 
         response = SacPZ.fetch(station=station)
 
-        assert isinstance(response, Response)
         assert response.network == "IU"
         assert response.station == "ANMO"
 

--- a/tests/classes/test_stationxml_class.py
+++ b/tests/classes/test_stationxml_class.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from pysmo import Location, MiniStation, Response, StagedResponse, Station
+from pysmo import MiniStation
 from pysmo.classes import StationXML, resolve_epochs
 
 SINGLE_EPOCH_FIXTURE = (
@@ -200,8 +200,6 @@ class TestFromBytes:
             SINGLE_EPOCH_FIXTURE.read_bytes(), time=pd.Timestamp("2016-01-01T00:00:00Z")
         )
 
-        assert isinstance(epoch, Station)
-        assert isinstance(epoch, Location)
         assert epoch.network == "IU"
         assert epoch.name == "ANMO"
         assert epoch.location == "00"
@@ -209,8 +207,6 @@ class TestFromBytes:
         assert epoch.latitude == pytest.approx(34.94591)
 
         response = epoch.response
-        assert isinstance(response, Response)
-        assert isinstance(response, StagedResponse)
         assert response.input_units == "m/s"
         assert len(response.stages) == 2
 
@@ -230,7 +226,6 @@ class TestFromBytes:
     def test_selects_currently_open_epoch(self) -> None:
         response = StationXML.from_bytes(BULK_FIXTURE.read_bytes()).response
 
-        assert isinstance(response, StagedResponse)
         assert len(response.poles) == 13
         assert len(response.stages) == 2
 
@@ -239,7 +234,6 @@ class TestFromBytes:
             BULK_FIXTURE.read_bytes(), time=pd.Timestamp("1999-01-01T00:00:00Z")
         ).response
 
-        assert isinstance(response, StagedResponse)
         assert len(response.stages) == 5
 
     def test_no_matching_epoch_raises(self) -> None:
@@ -306,8 +300,6 @@ class TestAllFromBytes:
         epochs = StationXML.all_from_bytes(BULK_FIXTURE.read_bytes())
         assert len(epochs) == 9
         for epoch in epochs:
-            assert isinstance(epoch, Station)
-            assert isinstance(epoch.response, StagedResponse)
             assert epoch.network == "IU"
             assert epoch.name == "ANMO"
         for previous, current in zip(epochs, epochs[1:]):
@@ -348,10 +340,7 @@ class TestFetch:
             station=station, time=pd.Timestamp("2016-01-01T00:00:00Z")
         )
 
-        assert isinstance(epoch, Station)
         response = epoch.response
-        assert isinstance(response, Response)
-        assert isinstance(response, StagedResponse)
         assert response.input_units == "m/s"
         assert len(response.stages) == 2
 
@@ -372,7 +361,6 @@ class TestFetch:
 
         response = StationXML.fetch(station=station).response
 
-        assert isinstance(response, StagedResponse)
         assert len(response.poles) == 13
         assert len(response.stages) == 2
 
@@ -388,7 +376,6 @@ class TestFetch:
             station=station, time=pd.Timestamp("1999-01-01T00:00:00Z")
         ).response
 
-        assert isinstance(response, StagedResponse)
         assert len(response.stages) == 5
 
     def test_no_matching_epoch_raises(

--- a/tests/docs/test_obspy_trace_recipe.py
+++ b/tests/docs/test_obspy_trace_recipe.py
@@ -23,7 +23,6 @@ import pytest
 
 obspy = pytest.importorskip("obspy")
 
-from pysmo import Seismogram  # noqa: E402
 from pysmo.functions import detrend  # noqa: E402
 
 SNIPPET_PATH = (
@@ -55,8 +54,6 @@ def test_trace_seismogram_recipe() -> None:
         },
     )
     trace_seis = TraceSeismogram(trace)
-
-    assert isinstance(trace_seis, Seismogram)
 
     original_data = trace.data.copy()
     detrend(trace_seis)

--- a/tests/tools/test_web.py
+++ b/tests/tools/test_web.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 import pandas as pd
 import pytest
 
-from pysmo import MiniStation, Response, StagedResponse
+from pysmo import MiniStation
 from pysmo.classes import QuakeML, SacPZ, StationXML
 from pysmo.tools.web import (
     fetch_quakeml,
@@ -92,8 +92,6 @@ class TestFetchStationxml:
         epoch = StationXML.from_bytes(xml, time=pd.Timestamp("2016-01-01T00:00:00Z"))
         response = epoch.response
 
-        assert isinstance(response, Response)
-        assert isinstance(response, StagedResponse)
         assert response.input_units == "m/s"
         assert len(response.stages) == 2
 
@@ -124,7 +122,6 @@ class TestFetchSacpz:
         text = fetch_sacpz(station=station)
         response = SacPZ.from_text(text)
 
-        assert isinstance(response, Response)
         assert response.network == "IU"
         assert response.station == "ANMO"
 

--- a/tests/tools/test_web_live.py
+++ b/tests/tools/test_web_live.py
@@ -25,7 +25,7 @@ import pytest
 from matplotlib.dates import date2num
 from matplotlib.figure import Figure
 
-from pysmo import Event, MiniEvent, MiniStation, Response
+from pysmo import MiniEvent, MiniStation
 from pysmo.classes import SAC, GeoCsvSeismogram, MSeed, QuakeML, SacPZ
 from pysmo.functions import detrend
 from pysmo.tools.azdist import haversine
@@ -92,7 +92,6 @@ def test_fetch_seismogram_live(station: MiniStation, event: MiniEvent) -> Figure
 def test_fetch_sacpz_live(station: MiniStation) -> None:
     response = SacPZ.fetch(station=station)
 
-    assert isinstance(response, Response)
     assert response.network == "IU"
     assert response.station == "ANMO"
     assert response.channel == "LHZ"
@@ -206,7 +205,6 @@ def test_fetch_mseed_multiple_segments_live() -> None:
 def test_fetch_quakeml_single_event_live() -> None:
     event = QuakeML.fetch(event_id="official20100227063411530_30")
 
-    assert isinstance(event, Event)
     assert event.magnitude is not None and event.magnitude >= 8.5
     assert event.time.year == 2010
 


### PR DESCRIPTION
Protocol conformance is now a static-only concern; isinstance against a pysmo protocol no longer works. Docstrings and tests that used isinstance checks now pass objects to functions typed against the protocol instead.

mini_utils gains a private _structural_match helper for the few tests that need a real structural check, and remove_response uses a local TypeIs guard in place of isinstance(response, StagedResponse). external-classes.md gains a section on TypeIs for genuine runtime dispatch and drops the beartype mention.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--308.org.readthedocs.build/en/308/

<!-- readthedocs-preview pysmo end -->