### PR TITLE
feat(archive): add FIFO max_bytes eviction to SqliteArchiveFetcher

### DIFF
--- a/src/pysmo/tools/archive.py
+++ b/src/pysmo/tools/archive.py
@@ -9,7 +9,8 @@ once is read back locally rather than re-fetched.
 Particularly useful as
 [`PysmoProject.fetch_seismogram`][pysmo.tools.project.PysmoProject.fetch_seismogram],
 so a project's entries are only ever fetched once across however many times
-the project is used.
+the project is used, provided entries remain in the cache (or when using an
+unbounded cache).
 
 Examples:
     [`SqliteArchiveFetcher`][pysmo.tools.archive.SqliteArchiveFetcher] stores
@@ -52,20 +53,57 @@ import sqlite3
 import threading
 import zlib
 from collections.abc import Callable
+from itertools import batched
 from pathlib import Path
 from typing import Any, Protocol
 
 import pandas as pd
-from attrs import define, field
+from attrs import define, field, validators
 
 from pysmo import Seismogram, Station
 from pysmo._utils import attrs_getstate, attrs_setstate
 from pysmo.lib.validators import convert_to_utc_timestamp
+from pysmo.typing import PositiveInt
 
 __all__ = ["RawFetcher", "RawParser", "SqliteArchiveFetcher"]
 
 _ENCODING_VERSION = 1
 """Raw bytes are stored zlib-compressed; bump this on any change to that encoding."""
+
+_LOW_WATER_FRACTION = 0.75
+"""Eviction target ratio of `max_bytes`.
+
+When the limit is crossed, the oldest entries are evicted until at most this
+fraction of `max_bytes` remains. The slack means a full cache does not
+re-check ground truth on every single miss; consecutive misses are O(1)
+between evictions."""
+
+_CREATE_CACHE_TABLE = (
+    "CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, data BLOB NOT NULL)"
+)
+_CREATE_CACHE_STATS_TABLE = (
+    "CREATE TABLE IF NOT EXISTS cache_stats "
+    + "(id INTEGER PRIMARY KEY CHECK (id = 1), total_bytes INTEGER NOT NULL)"
+)
+_CREATE_CACHE_INSERT_TRIGGER = (
+    "CREATE TRIGGER IF NOT EXISTS cache_insert_bytes "
+    + "AFTER INSERT ON cache "
+    + "BEGIN "
+    + "  UPDATE cache_stats "
+    + "  SET total_bytes = total_bytes + length(NEW.data) "
+    + "  WHERE id = 1; "
+    + "END"
+)
+_CREATE_CACHE_DELETE_TRIGGER = (
+    "CREATE TRIGGER IF NOT EXISTS cache_delete_bytes "
+    + "AFTER DELETE ON cache "
+    + "BEGIN "
+    + "  UPDATE cache_stats "
+    + "  SET total_bytes = MAX(total_bytes - length(OLD.data), 0) "
+    + "  WHERE id = 1; "
+    + "END"
+)
+"""Schema DDL shared with the tests so the two cannot diverge."""
 
 
 class RawFetcher(Protocol):
@@ -104,10 +142,12 @@ class SqliteArchiveFetcher:
 
     Format-agnostic: stores whatever bytes `fetch_raw` returns
     (zlib-compressed), keyed by station identity and time window, and hands
-    the decompressed bytes to `parse` on both a cache hit and a miss. A hit
-    never calls `fetch_raw` again; a side effect of this is bit-identical
-    replay of a previously fetched window, rather than only detecting drift
-    after the fact. `fetch_raw` runs outside the lock, so two threads racing
+    the decompressed bytes to `parse` on both a cache hit and a miss. While
+    an entry remains in the cache (or when `max_bytes=None`), a hit never
+    calls `fetch_raw` again; a side effect of this is bit-identical replay of a
+    previously fetched window, rather than only detecting drift after the fact.
+    If an entry is evicted under a finite `max_bytes`, subsequent access will
+    re-fetch it. `fetch_raw` runs outside the lock, so two threads racing
     the same not-yet-cached window both fetch before one result is stored.
 
     Warning: Local disk only
@@ -116,7 +156,9 @@ class SqliteArchiveFetcher:
         access to a SQLite database over NFS at all. This class assumes the
         database file lives on local disk with correctly functioning file
         locking; it is not a safe choice for a cache shared over a network
-        filesystem by more than one process at a time.
+        filesystem by more than one process at a time. Concurrent writers to
+        the same file may transiently desynchronise the `cache_stats`
+        counter; it self-heals on the next eviction's ground-truth re-check.
     """
 
     path: Path = field(converter=Path)
@@ -138,16 +180,53 @@ class SqliteArchiveFetcher:
     Only for a database confirmed to be on local disk (see the class docstring).
     """
 
+    max_bytes: PositiveInt | None = field(
+        default=None,
+        validator=validators.optional(validators.gt(0)),
+    )
+    """Maximum total size of compressed data stored in the cache, in bytes.
+
+    When a newly cached entry causes the total to exceed this limit, the
+    oldest entries (by insertion order) are evicted until the cache fits
+    within the limit again. If a single entry's compressed size exceeds
+    `max_bytes`, it is stored and kept rather than immediately evicted, so
+    the cache will hold exactly that one entry and every older entry will
+    be removed. Leave as `None` for unlimited storage.
+
+    Note: Compressed payload, trigger contract and eviction cost
+        This limit applies to the raw compressed `data` column bytes only.
+        Actual on-disk usage is higher due to SQLite page, B-tree index, and
+        WAL overhead; the real file will exceed `max_bytes` by a small
+        constant amount. Cache size is tracked using an internal
+        `cache_stats` table and database triggers, keeping hits and
+        under-limit misses O(1). Crossing the limit runs a ground-truth
+        re-check (an O(rows) pass) and evicts the oldest entries down to 75%
+        of `max_bytes`, so evictions are amortised over each quarter of
+        capacity rather than paid on every miss. Existing databases are
+        upgraded transparently without altering `user_version`. Direct
+        external writes that bypass the database triggers can cause tracked
+        size to lag until the counter crosses `max_bytes` and triggers
+        ground-truth verification. Entry order is SQLite's `rowid`, which
+        reproduces insertion order except after `VACUUM` or external row
+        writes.
+
+    Defaults to unlimited (`None`), matching a project's expectation that
+    a cached entry is never silently dropped and re-fetched.
+    """
+
     _conn: sqlite3.Connection | None = field(
         init=False, default=None, repr=False, eq=False
     )
     _lock: threading.Lock = field(
         init=False, factory=threading.Lock, repr=False, eq=False
     )
-    """Guards the check-then-set on `_conn`: `check_same_thread=False` means
-    this instance may legitimately be called from more than one thread, and
-    without this lock two threads racing the first call could each open
-    their own connection, silently leaking one."""
+    """Guards `_conn` setup and `_store`: `check_same_thread=False` means this
+    instance may legitimately be called from more than one thread. Without
+    the first guard, two threads racing the first call could each open their
+    own connection, silently leaking one. Without the second, two threads
+    sharing one connection could interleave writes into the same implicit
+    transaction, corrupting the `cache_stats` total or losing an insert to
+    another thread's rollback."""
 
     def __attrs_post_init__(self) -> None:
         """Fail fast if `path`'s parent directory doesn't exist."""
@@ -201,10 +280,6 @@ class SqliteArchiveFetcher:
                 conn = sqlite3.connect(self.path, timeout=30, check_same_thread=False)
                 if self.wal:
                     conn.execute("PRAGMA journal_mode=WAL")
-                conn.execute(
-                    "CREATE TABLE IF NOT EXISTS cache "
-                    + "(key TEXT PRIMARY KEY, data BLOB NOT NULL)"
-                )
                 version = conn.execute("PRAGMA user_version").fetchone()[0]
                 if version == 0:
                     conn.execute(f"PRAGMA user_version = {_ENCODING_VERSION}")
@@ -214,6 +289,18 @@ class SqliteArchiveFetcher:
                         f"{self.path} was written with a different cache "
                         + f"encoding (user_version={version}, expected "
                         + f"{_ENCODING_VERSION})."
+                    )
+                conn.execute(_CREATE_CACHE_TABLE)
+                conn.execute(_CREATE_CACHE_STATS_TABLE)
+                conn.execute(_CREATE_CACHE_INSERT_TRIGGER)
+                conn.execute(_CREATE_CACHE_DELETE_TRIGGER)
+                row = conn.execute(
+                    "SELECT total_bytes FROM cache_stats WHERE id = 1"
+                ).fetchone()
+                if row is None:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO cache_stats (id, total_bytes) "
+                        + "VALUES (1, (SELECT COALESCE(SUM(length(data)), 0) FROM cache))"
                     )
                 self._conn = conn
             return self._conn
@@ -238,12 +325,84 @@ class SqliteArchiveFetcher:
         if row is not None:
             return self.parse(zlib.decompress(row[0]))
         raw = self.fetch_raw(station=station, starttime=starttime, endtime=endtime)
-        with conn:
-            conn.execute(
-                "INSERT OR IGNORE INTO cache (key, data) VALUES (?, ?)",
-                (key, zlib.compress(raw)),
-            )
+        self._store(conn, key, zlib.compress(raw))
         return self.parse(raw)
+
+    def _store(self, conn: sqlite3.Connection, key: str, compressed: bytes) -> None:
+        with self._lock, conn:
+            cursor = conn.execute(
+                "INSERT OR IGNORE INTO cache (key, data) VALUES (?, ?)",
+                (key, compressed),
+            )
+            if cursor.rowcount > 0:
+                if cursor.lastrowid is None:
+                    raise RuntimeError("newly inserted cache row has no rowid")
+                self._evict(conn, cursor.lastrowid)
+
+    def _evict(self, conn: sqlite3.Connection, inserted_rowid: int) -> None:
+        max_bytes = self.max_bytes
+        if max_bytes is None:
+            return
+        if self._tracked_total(conn) <= max_bytes:
+            return
+        real = self._real_total(conn)
+        if real <= max_bytes:
+            # Tracked total overstated real usage (e.g. an uncounted external
+            # delete); heal the counter without evicting anything.
+            conn.execute("UPDATE cache_stats SET total_bytes = ? WHERE id = 1", (real,))
+            return
+        # Truly over limit: evict the oldest entries down to the low-water
+        # mark, so a full cache does not re-check ground truth every miss.
+        target = int(max_bytes * _LOW_WATER_FRACTION)
+        freed = self._delete_oldest(conn, inserted_rowid, real - target)
+        conn.execute(
+            "UPDATE cache_stats SET total_bytes = ? WHERE id = 1", (real - freed,)
+        )
+
+    def _tracked_total(self, conn: sqlite3.Connection) -> int:
+        row = conn.execute(
+            "SELECT total_bytes FROM cache_stats WHERE id = 1"
+        ).fetchone()
+        if row is not None and row[0] >= 0:
+            return row[0]
+        # Rebuild if the cache_stats row is missing or stale. A negative total
+        # is never legitimate and means the counter no longer matches which
+        # rows the triggers have accounted for.
+        real = self._real_total(conn)
+        conn.execute(
+            "INSERT OR REPLACE INTO cache_stats (id, total_bytes) VALUES (1, ?)",
+            (real,),
+        )
+        return real
+
+    def _real_total(self, conn: sqlite3.Connection) -> int:
+        return int(
+            conn.execute("SELECT COALESCE(SUM(length(data)), 0) FROM cache").fetchone()[
+                0
+            ]
+        )
+
+    def _delete_oldest(
+        self, conn: sqlite3.Connection, inserted_rowid: int, excess: int
+    ) -> int:
+        cursor_iter = conn.execute(
+            "SELECT rowid, length(data) FROM cache "
+            + "WHERE rowid != ? "
+            + "ORDER BY rowid ASC",
+            (inserted_rowid,),
+        )
+        to_delete: list[int] = []
+        freed = 0
+        for rowid, length in cursor_iter:
+            to_delete.append(rowid)
+            freed += length
+            if freed >= excess:
+                break
+        cursor_iter.close()
+        for chunk in batched(to_delete, 500):
+            placeholders = ",".join("?" * len(chunk))
+            conn.execute(f"DELETE FROM cache WHERE rowid IN ({placeholders})", chunk)
+        return freed
 
     @staticmethod
     def _key(station: Station, starttime: pd.Timestamp, endtime: pd.Timestamp) -> str:

--- a/src/pysmo/tools/project/__init__.py
+++ b/src/pysmo/tools/project/__init__.py
@@ -35,7 +35,9 @@ Pair `PysmoProject` with
 [`SqliteArchiveFetcher`][pysmo.tools.archive.SqliteArchiveFetcher] as its
 `fetch_seismogram` so a project's entries are only ever fetched once across
 however many sessions the project is used in (see the second example
-below). A different mechanism from
+below), provided `max_bytes` is left at its unlimited default; a finite
+`max_bytes` evicts old entries, which are then re-fetched on next access. A
+different mechanism from
 [`ProjectEntry.checksum`][pysmo.tools.project.ProjectEntry.checksum], which
 only detects drift on the live-network default rather than avoiding it.
 

--- a/src/pysmo/tools/project/_project.py
+++ b/src/pysmo/tools/project/_project.py
@@ -227,7 +227,10 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
     instance instead. That is the *recommended* value for real analysis
     work, not a power-user option on equal footing with the default; see its
     own docstring for why, and how it differs from `ProjectEntry.checksum`'s
-    live-fetch drift detection. It only pins the waveform, though: see the
+    live-fetch drift detection. Leave its `max_bytes` at the default
+    (unlimited) for this to hold: a finite `max_bytes` evicts old entries and
+    re-fetches them on next access, reintroducing the drift a cache is meant
+    to rule out. It only pins the waveform, though: see the
     [module documentation][pysmo.tools.project]'s second example for the
     gotcha it does not cover, `seismogram_transform` making its own
     additional fetches. Any other callable of the right shape (e.g. one

--- a/tests/tools/test_archive.py
+++ b/tests/tools/test_archive.py
@@ -4,6 +4,7 @@ import gc
 import pickle
 import sqlite3
 import sys
+import zlib
 from pathlib import Path
 
 import pandas as pd
@@ -11,7 +12,10 @@ import pytest
 
 from pysmo import MiniSeismogram, MiniStation, Seismogram, Station
 from pysmo.classes import SAC
-from pysmo.tools.archive import SqliteArchiveFetcher
+from pysmo.tools.archive import (
+    _CREATE_CACHE_INSERT_TRIGGER,
+    SqliteArchiveFetcher,
+)
 from pysmo.tools.web import fetch_sac
 
 RAW_BYTES = b"1.0,2.0,3.0"
@@ -140,6 +144,32 @@ class TestEncodingVersion:
         )
         with pytest.raises(ValueError, match="user_version"):
             archive(station, starttime, endtime)
+
+    def test_mismatched_version_does_not_mutate_schema(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+        endtime: pd.Timestamp,
+    ) -> None:
+        path = tmp_path / "archive.sqlite3"
+        conn = sqlite3.connect(path)
+        conn.execute("PRAGMA user_version = 999")
+        conn.commit()
+        conn.close()
+
+        archive = SqliteArchiveFetcher(
+            path=path, fetch_raw=fake_fetch_raw, parse=fake_parse
+        )
+        with pytest.raises(ValueError, match="user_version"):
+            archive(station, starttime, endtime)
+
+        conn = sqlite3.connect(path)
+        objects = conn.execute(
+            "SELECT type, name FROM sqlite_master WHERE type IN ('table', 'trigger')"
+        ).fetchall()
+        conn.close()
+        assert objects == []
 
 
 class TestWalFlag:
@@ -326,6 +356,457 @@ class TestConstructionTimeValidation:
             fetch_raw=fake_fetch_raw,
             parse=fake_parse,
         )
+
+    @pytest.mark.parametrize("max_bytes", [-1, 0])
+    def test_non_positive_max_bytes_raises(
+        self, tmp_path: Path, max_bytes: int
+    ) -> None:
+        with pytest.raises(ValueError, match="max_bytes"):
+            SqliteArchiveFetcher(
+                path=tmp_path / "archive.sqlite3",
+                fetch_raw=fake_fetch_raw,
+                parse=fake_parse,
+                max_bytes=max_bytes,
+            )
+
+
+class TestMaxBytes:
+    """FIFO eviction via max_bytes."""
+
+    def _count_rows(self, archive: SqliteArchiveFetcher) -> int:
+        return archive._connect().execute("SELECT COUNT(*) FROM cache").fetchone()[0]
+
+    def _total_bytes(self, archive: SqliteArchiveFetcher) -> int:
+        result = (
+            archive._connect()
+            .execute("SELECT COALESCE(SUM(length(data)), 0) FROM cache")
+            .fetchone()[0]
+        )
+        return int(result)
+
+    def _one_entry_bytes(
+        self, tmp_path: Path, station: MiniStation, starttime: pd.Timestamp
+    ) -> int:
+        """Measure the compressed size of a single cached entry."""
+        probe = SqliteArchiveFetcher(
+            path=tmp_path / "probe.sqlite3",
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+        )
+        probe(station, starttime, starttime + pd.Timedelta(minutes=1))
+        size = self._total_bytes(probe)
+        probe.close()
+        return size
+
+    def test_default_is_unlimited(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+        endtime: pd.Timestamp,
+    ) -> None:
+        archive = SqliteArchiveFetcher(
+            path=tmp_path / "archive.sqlite3",
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+        )
+        for i in range(10):
+            t = starttime + pd.Timedelta(minutes=i)
+            archive(station, t, t + pd.Timedelta(minutes=1))
+
+        assert self._count_rows(archive) == 10
+
+    def test_evicts_oldest_when_limit_exceeded(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+    ) -> None:
+        one_entry_bytes = self._one_entry_bytes(tmp_path, station, starttime)
+        limit = one_entry_bytes * 2
+        archive = SqliteArchiveFetcher(
+            path=tmp_path / "archive.sqlite3",
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+            max_bytes=limit,
+        )
+
+        for i in range(5):
+            s = starttime + pd.Timedelta(minutes=i)
+            archive(station, s, s + pd.Timedelta(minutes=1))
+
+        # Eviction targets the low-water mark (75% of the limit), so a burst
+        # into a 2-entry cache ends holding only the newest entry.
+        assert self._count_rows(archive) == 1
+        assert self._total_bytes(archive) <= limit
+
+    def test_oldest_entry_is_gone_after_eviction(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+    ) -> None:
+        one_entry_bytes = self._one_entry_bytes(tmp_path, station, starttime)
+        t0, t1 = starttime, starttime + pd.Timedelta(minutes=1)
+        t2, t3 = t1, starttime + pd.Timedelta(minutes=2)
+
+        # One-entry limit: every new write evicts the previous one.
+        archive = SqliteArchiveFetcher(
+            path=tmp_path / "archive.sqlite3",
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+            max_bytes=one_entry_bytes,
+        )
+        archive(station, t0, t1)
+        archive(station, t2, t3)
+
+        conn = archive._connect()
+        key_old = SqliteArchiveFetcher._key(station, t0, t1)
+        key_new = SqliteArchiveFetcher._key(station, t2, t3)
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM cache WHERE key = ?", (key_old,)
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM cache WHERE key = ?", (key_new,)
+            ).fetchone()[0]
+            == 1
+        )
+
+    def test_oversized_entry_is_kept_not_thrashed(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+    ) -> None:
+        """An entry larger than max_bytes must not be evicted immediately.
+
+        If it were, fetch_raw would be called on every subsequent access,
+        breaking the "only ever fetched once" guarantee.
+        """
+        one_entry_bytes = self._one_entry_bytes(tmp_path, station, starttime)
+        FETCH_CALLS.clear()  # exclude the probe fetch from the count
+        t0, t1 = starttime, starttime + pd.Timedelta(minutes=1)
+
+        # Limit smaller than a single entry.
+        archive = SqliteArchiveFetcher(
+            path=tmp_path / "archive.sqlite3",
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+            max_bytes=one_entry_bytes - 1,
+        )
+        archive(station, t0, t1)  # miss — fetches and stores
+        archive(station, t0, t1)  # must be a hit, NOT a second fetch
+
+        assert len(FETCH_CALLS) == 1
+        assert self._count_rows(archive) == 1
+
+    def test_evicted_entry_refetched_on_next_access(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+    ) -> None:
+        """After eviction, a subsequent access to the evicted key re-fetches."""
+        one_entry_bytes = self._one_entry_bytes(tmp_path, station, starttime)
+        FETCH_CALLS.clear()  # exclude the probe fetch from the count
+        t0, t1 = starttime, starttime + pd.Timedelta(minutes=1)
+        t2, t3 = t1, starttime + pd.Timedelta(minutes=2)
+
+        # One-entry limit: inserting t2 evicts t0.
+        archive = SqliteArchiveFetcher(
+            path=tmp_path / "archive.sqlite3",
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+            max_bytes=one_entry_bytes,
+        )
+        archive(station, t0, t1)  # fetch #1
+        archive(station, t2, t3)  # fetch #2, evicts t0
+        archive(station, t0, t1)  # t0 gone — must re-fetch (#3)
+
+        assert len(FETCH_CALLS) == 3
+
+    def test_no_shrink_on_read_only_access(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+    ) -> None:
+        """Reopening an already-over-limit cache never evicts on the hit path."""
+        one_entry_bytes = self._one_entry_bytes(tmp_path, station, starttime)
+        FETCH_CALLS.clear()  # exclude the probe fetch from the count
+        path = tmp_path / "archive.sqlite3"
+
+        # Fill the cache with two entries while unlimited.
+        fill = SqliteArchiveFetcher(
+            path=path,
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+        )
+        t0, t1 = starttime, starttime + pd.Timedelta(minutes=1)
+        t2, t3 = t1, starttime + pd.Timedelta(minutes=2)
+        fill(station, t0, t1)
+        fill(station, t2, t3)
+        fill.close()
+
+        # Reopen with a limit smaller than the existing total.
+        restricted = SqliteArchiveFetcher(
+            path=path,
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+            max_bytes=one_entry_bytes,
+        )
+        restricted(station, t0, t1)  # hit — must not evict
+        restricted(station, t2, t3)  # hit — must not evict
+
+        assert len(FETCH_CALLS) == 2  # only the two fill() fetches
+        assert self._count_rows(restricted) == 2  # both entries still present
+
+    def test_legacy_database_bootstrapped_and_evicted(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+    ) -> None:
+        """A legacy database with existing rows bootstraps cache_stats and evicts."""
+        path = tmp_path / "legacy.sqlite3"
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE cache (key TEXT PRIMARY KEY, data BLOB NOT NULL)")
+        conn.execute("PRAGMA user_version = 1")
+        k1 = SqliteArchiveFetcher._key(
+            station, starttime, starttime + pd.Timedelta(minutes=1)
+        )
+        k2 = SqliteArchiveFetcher._key(
+            station,
+            starttime + pd.Timedelta(minutes=1),
+            starttime + pd.Timedelta(minutes=2),
+        )
+        blob = zlib.compress(RAW_BYTES)
+        conn.execute("INSERT INTO cache (key, data) VALUES (?, ?)", (k1, blob))
+        conn.execute("INSERT INTO cache (key, data) VALUES (?, ?)", (k2, blob))
+        conn.commit()
+        conn.close()
+
+        limit = len(blob) * 2
+        archive = SqliteArchiveFetcher(
+            path=path,
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+            max_bytes=limit,
+        )
+        conn = archive._connect()
+        stats_bytes = conn.execute(
+            "SELECT total_bytes FROM cache_stats WHERE id = 1"
+        ).fetchone()[0]
+        assert stats_bytes == len(blob) * 2
+
+        FETCH_CALLS.clear()
+        archive(
+            station,
+            starttime + pd.Timedelta(minutes=2),
+            starttime + pd.Timedelta(minutes=3),
+        )
+        # The two legacy rows are evicted (down to the low-water mark), leaving
+        # only the freshly inserted entry.
+        assert self._count_rows(archive) == 1
+        assert self._total_bytes(archive) <= limit
+        assert (
+            conn.execute("SELECT COUNT(*) FROM cache WHERE key = ?", (k1,)).fetchone()[
+                0
+            ]
+            == 0
+        )
+
+    def test_missing_cache_stats_row_heals(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+    ) -> None:
+        """Deleting the cache_stats row does not crash and lazily heals."""
+        archive = SqliteArchiveFetcher(
+            path=tmp_path / "archive.sqlite3",
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+            max_bytes=1000,
+        )
+        t0, t1 = starttime, starttime + pd.Timedelta(minutes=1)
+        t2, t3 = t1, starttime + pd.Timedelta(minutes=2)
+        archive(station, t0, t1)
+
+        conn = archive._connect()
+        with conn:
+            conn.execute("DELETE FROM cache_stats")
+
+        FETCH_CALLS.clear()
+        archive(station, t2, t3)
+        assert len(FETCH_CALLS) == 1
+        stats_bytes = conn.execute(
+            "SELECT total_bytes FROM cache_stats WHERE id = 1"
+        ).fetchone()
+        assert stats_bytes is not None
+        assert stats_bytes[0] == self._total_bytes(archive)
+
+    def test_negative_stats_total_heals(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+    ) -> None:
+        """A negative cache_stats total is never legitimate and must rebuild."""
+        one_entry_bytes = self._one_entry_bytes(tmp_path, station, starttime)
+        FETCH_CALLS.clear()
+        archive = SqliteArchiveFetcher(
+            path=tmp_path / "archive.sqlite3",
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+            max_bytes=one_entry_bytes,
+        )
+        t0, t1 = starttime, starttime + pd.Timedelta(minutes=1)
+        t2, t3 = t1, starttime + pd.Timedelta(minutes=2)
+        archive(station, t0, t1)
+
+        conn = archive._connect()
+        # Simulate a stale counter (e.g. trigger-driven deletes of rows that
+        # were never counted) that has gone negative.
+        with conn:
+            conn.execute("UPDATE cache_stats SET total_bytes = -1000 WHERE id = 1")
+
+        FETCH_CALLS.clear()
+        archive(station, t2, t3)
+
+        # The negative total must be treated as stale: rebuilt from ground
+        # truth, then eviction proceeds (and heals) normally.
+        assert len(FETCH_CALLS) == 1
+        assert self._count_rows(archive) == 1
+        assert self._total_bytes(archive) <= one_entry_bytes
+        stats_bytes = conn.execute(
+            "SELECT total_bytes FROM cache_stats WHERE id = 1"
+        ).fetchone()[0]
+        assert stats_bytes == self._total_bytes(archive)
+
+    def test_bypass_desync_heals_on_eviction(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+    ) -> None:
+        """If cache_stats desyncs, eviction re-checks ground truth and heals."""
+        one_entry_bytes = self._one_entry_bytes(tmp_path, station, starttime)
+        FETCH_CALLS.clear()
+        limit = one_entry_bytes * 2
+        archive = SqliteArchiveFetcher(
+            path=tmp_path / "archive.sqlite3",
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+            max_bytes=limit,
+        )
+        t0, t1 = starttime, starttime + pd.Timedelta(minutes=1)
+        t2, t3 = t1, starttime + pd.Timedelta(minutes=2)
+        t4, t5 = t3, starttime + pd.Timedelta(minutes=3)
+        t6, t7 = t5, starttime + pd.Timedelta(minutes=4)
+        archive(station, t0, t1)
+        archive(station, t2, t3)
+
+        conn = archive._connect()
+        # Drop the insert trigger to simulate an external write or bypass
+        with conn:
+            conn.execute("DROP TRIGGER cache_insert_bytes")
+            # Uncounted insert: real total becomes 3 entries, but stats says 2
+            blob = zlib.compress(RAW_BYTES)
+            key_uncounted = SqliteArchiveFetcher._key(station, t4, t5)
+            conn.execute(
+                "INSERT INTO cache (key, data) VALUES (?, ?)",
+                (key_uncounted, blob),
+            )
+
+        # Re-add trigger as would happen on reconnect
+        with conn:
+            conn.execute(_CREATE_CACHE_INSERT_TRIGGER)
+
+        # Next insert via archive pushes stats over limit.
+        # Eviction re-checks ground truth, evicts below the low-water mark and
+        # reconciles cache_stats with the real total.
+        archive(station, t6, t7)
+        assert self._count_rows(archive) == 1
+        assert self._total_bytes(archive) <= limit
+        stats_bytes = conn.execute(
+            "SELECT total_bytes FROM cache_stats WHERE id = 1"
+        ).fetchone()[0]
+        assert stats_bytes == self._total_bytes(archive)
+
+    def test_bypass_desync_under_cap_not_healed_until_crossing(
+        self,
+        tmp_path: Path,
+        station: MiniStation,
+        starttime: pd.Timestamp,
+    ) -> None:
+        """Under-cap bypass writes do not heal until the tracked total crosses limit.
+
+        Documents the architectural trade-off: inserts remain O(1) by trusting
+        triggers, so uncounted external writes remain unhealed while tracked
+        total is below max_bytes. Once tracked total crosses max_bytes,
+        eviction engages, re-verifies ground truth, and heals.
+        """
+        one_entry_bytes = self._one_entry_bytes(tmp_path, station, starttime)
+        FETCH_CALLS.clear()
+        # Allow 4 entries
+        limit = one_entry_bytes * 4
+        archive = SqliteArchiveFetcher(
+            path=tmp_path / "archive.sqlite3",
+            fetch_raw=fake_fetch_raw,
+            parse=fake_parse,
+            max_bytes=limit,
+        )
+        t0, t1 = starttime, starttime + pd.Timedelta(minutes=1)
+        t2, t3 = t1, starttime + pd.Timedelta(minutes=2)
+        t4, t5 = t3, starttime + pd.Timedelta(minutes=3)
+        t6, t7 = t5, starttime + pd.Timedelta(minutes=4)
+        t8, t9 = t7, starttime + pd.Timedelta(minutes=5)
+        archive(station, t0, t1)
+        archive(station, t2, t3)
+
+        conn = archive._connect()
+        # Drop trigger and insert uncounted rows
+        with conn:
+            conn.execute("DROP TRIGGER cache_insert_bytes")
+            blob = zlib.compress(RAW_BYTES)
+            conn.execute(
+                "INSERT INTO cache (key, data) VALUES (?, ?)",
+                (SqliteArchiveFetcher._key(station, t4, t5), blob),
+            )
+            conn.execute(
+                "INSERT INTO cache (key, data) VALUES (?, ?)",
+                (SqliteArchiveFetcher._key(station, t6, t7), blob),
+            )
+            # Re-create trigger
+            conn.execute(_CREATE_CACHE_INSERT_TRIGGER)
+
+        # Real table has 4 entries (limit), but stats only tracked 2 entries.
+        # Inserting a 5th entry via archive increases tracked stats to 3 (< limit).
+        archive(station, t8, t9)
+        # Because tracked stats <= limit, O(1) fast-path skips table scan;
+        # the cache temporarily holds 5 entries (> limit).
+        assert self._count_rows(archive) == 5
+
+        # Inserting two more entries pushes tracked stats past limit.
+        t10, t11 = t9, starttime + pd.Timedelta(minutes=6)
+        t12, t13 = t11, starttime + pd.Timedelta(minutes=7)
+        archive(station, t10, t11)
+        archive(station, t12, t13)
+
+        # Now eviction has engaged: ground truth was verified, older entries
+        # were evicted down to the low-water mark, and total is strictly
+        # <= limit.
+        assert self._count_rows(archive) == 3
+        assert self._total_bytes(archive) <= limit
+        stats_bytes = conn.execute(
+            "SELECT total_bytes FROM cache_stats WHERE id = 1"
+        ).fetchone()[0]
+        assert stats_bytes == self._total_bytes(archive)
 
 
 def test_fetch_mseed_pairing(


### PR DESCRIPTION
Add a `max_bytes` parameter (default `None`/unlimited) capping the SQLite cache's total compressed size. Size is tracked with a `cache_stats` table and triggers so hits and under-limit misses stay O(1); crossing the limit re-verifies against the real total and evicts the oldest entries (by rowid) down to 75% of the limit, self-healing the counter along the way.

`_store`'s insert-and-evict is now guarded by the existing connection lock, since `check_same_thread=False` allows concurrent callers to share one connection.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--313.org.readthedocs.build/en/313/

<!-- readthedocs-preview pysmo end -->