### PR TITLE
refactor(functions): rename `clone` argument to `replace`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,7 +36,7 @@ Pysmo separates **types** (protocols), **storage** (concrete classes), and **pro
 
 ### Functions (`src/pysmo/functions/`)
 
-Low-level building blocks operating on protocol types. Functions that modify seismograms follow a **clone pattern**: called without `clone` they mutate in place and return `None`; called with `clone=True` they return a `deepcopy`. Avoid `obj = fn(obj, clone=True)` — use in-place mutation instead.
+Low-level building blocks operating on protocol types. Functions that modify seismograms follow a **replace pattern**: called without `replace` they mutate in place and return `None`; called with `replace=True` they leave the input untouched and return a new seismogram, rebuilt from the input with only `data` (and `begin_time`/`delta` where relevant) substituted. Not every concrete type supports it — `SacSeismogram` raises `TypeError`. Avoid `obj = fn(obj, replace=True)` — use in-place mutation instead.
 
 ### Tools (`src/pysmo/tools/`)
 

--- a/docs/usage/functions.md
+++ b/docs/usage/functions.md
@@ -38,7 +38,7 @@ array([2., 2., 3.])
 The array was modified *inside* the function, yet the change is visible
 *outside* it: both the caller and the function hold a reference to the same
 object. This is sometimes the intent, but it needs to be a deliberate choice.
-The `clone` argument below comes back to this.
+The `replace` argument below comes back to this.
 
 ## Pysmo types as input
 
@@ -75,7 +75,14 @@ shows the problem:
     does not copy it. [`deepcopy`][copy.deepcopy] is used here to make an
     independent copy before modifying it, leaving the caller's object
     untouched. Pysmo functions that modify seismograms offer this through a
-    `clone` argument. Deep-copying can be expensive for large objects.
+    `replace` argument, which returns a new seismogram with only the changed
+    attributes substituted. It works for value-object types such as
+    [`MiniSeismogram`][pysmo.MiniSeismogram] but raises `TypeError` for a
+    [`SacSeismogram`][pysmo.classes.SacSeismogram], whose `data` is a live
+    view into an open SAC file rather than a stored field. The manual
+    `deepcopy` shown here is a teaching device, not a recommendation. To
+    work on independent SAC data, copy the [`SAC`][pysmo.classes.SAC] object
+    itself.
 
 The snippet creates a [`SacSeismogram`][pysmo.classes.SacSeismogram] instance
 from a SAC file and passes it to `double_delta`. Inside the function it is
@@ -195,11 +202,11 @@ The `detrend` function looks like it is declared several times. At runtime the
 are only for type checkers. Read from *bottom to top*:
 
 - `detrend` takes two arguments. The type of `seismogram` is captured in the
-    variable `T` (bound by `Seismogram`), and `clone` is a [`bool`][] defaulting
-    to [`False`][]. The function returns either [`None`][] or a value of type
-    `T`.
-- If `clone` is [`True`][], an object of type `T` is returned.
-- If `clone` is `False` (the default), `None` is returned. `T` is not needed
+    variable `T` (bound by `Seismogram`), and `replace` is a [`bool`][]
+    defaulting to [`False`][]. The function returns either [`None`][] or a value
+    of type `T`.
+- If `replace` is [`True`][], an object of type `T` is returned.
+- If `replace` is `False` (the default), `None` is returned. `T` is not needed
     here: it is not reused elsewhere in this declaration, so a type variable
     serves no purpose.
 
@@ -219,4 +226,4 @@ are only for type checkers. Read from *bottom to top*:
   - Use a generic (`[T: Seismogram]`) when the caller's exact type must be
         preserved.
   - Use `overload` when the return type depends on the value of an argument,
-        such as `clone`.
+        such as `replace`.

--- a/src/pysmo/functions/__init__.py
+++ b/src/pysmo/functions/__init__.py
@@ -7,29 +7,71 @@ common operations on [`pysmo`][] types. They are intended as building blocks
 for constructing more complex processing workflows.
 --8<-- [end:in-the-box]
 
-Many functions accept a `clone` argument that controls whether the function
-operates on the input directly or first creates a clone (via
-[`deepcopy`][copy.deepcopy]) and returns the modified copy. For example:
+Many functions accept a `replace` argument. Without it they modify the
+seismogram in place and return `None`; with `replace=True` they leave the
+input untouched and return a new seismogram. For example:
 
 ```python
 >>> from pysmo.functions import resample
->>> from pysmo.classes import SAC
->>> sac_seis = SAC.from_file("example.sac").seismogram
->>> new_delta = sac_seis.delta * 2
+>>> from pysmo.classes import MSeed
+>>> seis = MSeed.from_file("example.mseed")
+>>> new_delta = seis.delta * 2
 >>>
->>> # create a clone and modify data in clone instead of sac_seis:
->>> new_sac_seis = resample(sac_seis, new_delta, clone=True)
+>>> # return a new seismogram, leaving seis untouched:
+>>> new_seis = resample(seis, new_delta, replace=True)
 >>>
->>> # modify data in sac_seis directly:
->>> resample(sac_seis, new_delta)
+>>> # modify data in seis directly:
+>>> resample(seis, new_delta)
 >>>
 ```
 
-Note: Needless deepcopy
-    Reassigning the clone back to the same name (`sac_seis = resample(sac_seis,
-    new_delta, clone=True)`) ends up equivalent to modifying `sac_seis` in
-    place, but pays for a [`deepcopy`][copy.deepcopy] to get there. Call
-    `resample(sac_seis, new_delta)` directly instead.
+The new object is built from the input with [`copy.replace`][],
+substituting only the freshly computed [`data`][pysmo.Seismogram.data]
+(and, where the operation moves or resamples the time axis, the
+corresponding [`begin_time`][pysmo.Seismogram.begin_time] or
+[`delta`][pysmo.Seismogram.delta]). Every other attribute is carried
+straight over from the input.
+
+Warning: Attributes outside the `Seismogram` protocol
+    A concrete class often carries more than `begin_time`, `delta` and
+    `data`: identity, provenance or acquisition metadata. `replace=True`
+    keeps those values as they were, even where the operation has made them
+    a poor description of the new data, and copies them shallowly. If such
+    an attribute is itself mutable, the input and the returned seismogram
+    share the same object, so mutating it through one is visible through
+    the other.
+
+Not every concrete type supports `replace=True`: rebuilding the object this
+way needs the substituted attributes to be constructor parameters.
+[`MiniSeismogram`][pysmo.MiniSeismogram], [`MSeed`][pysmo.classes.MSeed] and
+other value objects qualify; [`SacSeismogram`][pysmo.classes.SacSeismogram]
+does not, because its `data` is a live view into an open SAC file rather
+than a stored field.
+
+```python
+>>> from pysmo.functions import clone_to_mini, detrend
+>>> from pysmo import MiniSeismogram
+>>> from pysmo.classes import SAC
+>>> sac = SAC.from_file("example.sac")
+>>>
+>>> # replace=True cannot rebuild a SacSeismogram:
+>>> detrend(sac.seismogram, replace=True)
+Traceback (most recent call last):
+...
+TypeError: ...
+>>>
+>>> # convert to a value object first (or copy the whole SAC object):
+>>> detrended = detrend(clone_to_mini(MiniSeismogram, sac.seismogram), replace=True)
+>>> type(detrended).__name__
+'MiniSeismogram'
+>>>
+```
+
+Note: Needless copy
+    Reassigning the result back to the same name (`seis = resample(seis,
+    new_delta, replace=True)`) ends up equivalent to modifying `seis` in
+    place, but pays for a copy to get there. Call `resample(seis, new_delta)`
+    directly instead.
 
 Hint: More functions live in `pysmo.tools`
     Additional functions may be found in [`pysmo.tools`][].

--- a/src/pysmo/functions/_seismogram.py
+++ b/src/pysmo/functions/_seismogram.py
@@ -1,6 +1,6 @@
+import copy
 import statistics
 from collections.abc import Sequence
-from copy import deepcopy
 from itertools import pairwise
 from math import floor
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
@@ -43,7 +43,7 @@ def crop(
     begin_time: pd.Timestamp,
     end_time: pd.Timestamp,
     *,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
 ) -> None: ...
 @overload
 def crop[T: Seismogram](
@@ -51,7 +51,7 @@ def crop[T: Seismogram](
     begin_time: pd.Timestamp,
     end_time: pd.Timestamp,
     *,
-    clone: Literal[True],
+    replace: Literal[True],
 ) -> T: ...
 
 
@@ -60,7 +60,7 @@ def crop[T: Seismogram](
     begin_time: pd.Timestamp,
     end_time: pd.Timestamp,
     *,
-    clone: bool = False,
+    replace: bool = False,
 ) -> T | None:
     """Shorten a seismogram to new begin and end times.
 
@@ -73,10 +73,12 @@ def crop[T: Seismogram](
         seismogram: [`Seismogram`][pysmo.Seismogram] object.
         begin_time: New begin time.
         end_time: New end time.
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
 
     Returns:
-        Cropped [`Seismogram`][pysmo.Seismogram] object if called with `clone=True`.
+        Cropped [`Seismogram`][pysmo.Seismogram] object if called with `replace=True`.
 
     Raises:
         ValueError: If new begin time is after new end time.
@@ -100,33 +102,41 @@ def crop[T: Seismogram](
     start_index = time2index(seismogram, begin_time)
     end_index = time2index(seismogram, end_time)
 
-    if clone is True:
-        seismogram = deepcopy(seismogram)
+    new_data = seismogram.data[start_index : end_index + 1]
+    new_begin_time = seismogram.begin_time + seismogram.delta * start_index
 
-    seismogram.data = seismogram.data[start_index : end_index + 1]
-    seismogram.begin_time += seismogram.delta * start_index
+    if replace:
+        return copy.replace(
+            seismogram,  # type: ignore[arg-type]
+            data=new_data.copy(),
+            begin_time=new_begin_time,
+        )
 
-    return seismogram if clone is True else None
+    seismogram.data = new_data
+    seismogram.begin_time = new_begin_time
+    return None
 
 
 # --8<-- [start:detrend]
 @overload
-def detrend(seismogram: Seismogram, *, clone: Literal[False] = ...) -> None: ...
+def detrend(seismogram: Seismogram, *, replace: Literal[False] = ...) -> None: ...
 
 
 @overload
-def detrend[T: Seismogram](seismogram: T, *, clone: Literal[True]) -> T: ...
+def detrend[T: Seismogram](seismogram: T, *, replace: Literal[True]) -> T: ...
 
 
-def detrend[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | None:
+def detrend[T: Seismogram](seismogram: T, *, replace: bool = False) -> T | None:
     """Remove linear and/or constant trends from a seismogram.
 
     Args:
         seismogram: Seismogram object.
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
 
     Returns:
-        Detrended [`Seismogram`][pysmo.Seismogram] object if called with `clone=True`.
+        Detrended [`Seismogram`][pysmo.Seismogram] object if called with `replace=True`.
 
     Examples:
         ```python
@@ -143,13 +153,12 @@ def detrend[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | None:
         >>>
         ```
     """
-    if clone is True:
-        seismogram = deepcopy(seismogram)
+    detrended = scipy.signal.detrend(seismogram.data)
 
-    seismogram.data = scipy.signal.detrend(seismogram.data)
+    if replace:
+        return copy.replace(seismogram, data=detrended)  # type: ignore[arg-type]
 
-    if clone is True:
-        return seismogram
+    seismogram.data = detrended
     return None
 
 
@@ -162,7 +171,7 @@ def normalize(
     t1: pd.Timestamp | None = ...,
     t2: pd.Timestamp | None = ...,
     *,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
 ) -> None: ...
 @overload
 def normalize[T: Seismogram](
@@ -170,7 +179,7 @@ def normalize[T: Seismogram](
     t1: pd.Timestamp | None = ...,
     t2: pd.Timestamp | None = ...,
     *,
-    clone: Literal[True],
+    replace: Literal[True],
 ) -> T: ...
 
 
@@ -179,7 +188,7 @@ def normalize[T: Seismogram](
     t1: pd.Timestamp | None = None,
     t2: pd.Timestamp | None = None,
     *,
-    clone: bool = False,
+    replace: bool = False,
 ) -> T | None:
     """Normalise a seismogram with its absolute max value.
 
@@ -189,10 +198,12 @@ def normalize[T: Seismogram](
             starts from the beginning of the seismogram.
         t2: End of the window used to find the maximum. If `None`, the search
             continues to the end of the seismogram.
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
 
     Returns:
-        Normalised [`Seismogram`][pysmo.Seismogram] object if `clone=True`.
+        Normalised [`Seismogram`][pysmo.Seismogram] object if `replace=True`.
 
     Raises:
         ValueError: If the absolute maximum of the data (within the optional
@@ -229,14 +240,13 @@ def normalize[T: Seismogram](
             + "is given) is zero."
         )
 
-    if clone is True:
-        seismogram = deepcopy(seismogram)
+    if replace:
+        return copy.replace(
+            seismogram,  # type: ignore[arg-type]
+            data=seismogram.data / abs_max,
+        )
 
     seismogram.data /= abs_max
-
-    if clone is True:
-        return seismogram
-
     return None
 
 
@@ -247,7 +257,7 @@ def pad[T: Seismogram](
     end_time: pd.Timestamp,
     mode: "_ModeKind | _ModeFunc" = "constant",
     *,
-    clone: Literal[True],
+    replace: Literal[True],
     **kwargs: Any,
 ) -> T: ...
 
@@ -259,7 +269,7 @@ def pad(
     end_time: pd.Timestamp,
     mode: "_ModeKind | _ModeFunc" = "constant",
     *,
-    clone: Literal[False] = False,
+    replace: Literal[False] = False,
     **kwargs: Any,
 ) -> None: ...
 
@@ -270,7 +280,7 @@ def pad[T: Seismogram](
     end_time: pd.Timestamp,
     mode: "_ModeKind | _ModeFunc" = "constant",
     *,
-    clone: bool = False,
+    replace: bool = False,
     **kwargs: Any,
 ) -> T | None:
     """Pad seismogram data.
@@ -287,11 +297,13 @@ def pad[T: Seismogram](
         begin_time: New begin time.
         end_time: New end time.
         mode: Pad mode to use (see [`numpy.pad`][] for all modes).
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
         kwargs: Keyword arguments to pass to [`numpy.pad`][].
 
     Returns:
-        Padded [`Seismogram`][pysmo.Seismogram] object if called with `clone=True`.
+        Padded [`Seismogram`][pysmo.Seismogram] object if called with `replace=True`.
 
     Raises:
         ValueError: If new begin time is after new end time.
@@ -325,13 +337,33 @@ def pad[T: Seismogram](
     start_index = time2index(seismogram, begin_time, allow_out_of_bounds=True)
     end_index = time2index(seismogram, end_time, allow_out_of_bounds=True)
 
-    if clone is True:
-        seismogram = deepcopy(seismogram)
-
     pad_before = max(0, -start_index)
     pad_after = max(0, end_index - (len(seismogram.data) - 1))
+    padding_needed = pad_before > 0 or pad_after > 0
 
-    if pad_before > 0 or pad_after > 0:
+    if replace:
+        if padding_needed:
+            new_data = np.pad(
+                seismogram.data,
+                pad_width=(pad_before, pad_after),
+                mode=mode,
+                **kwargs,
+            )
+            new_begin_time = seismogram.begin_time + seismogram.delta * min(
+                0, start_index
+            )
+        else:
+            # replace=True must always hand back a fully independent object,
+            # even when there is nothing to pad.
+            new_data = seismogram.data.copy()
+            new_begin_time = seismogram.begin_time
+        return copy.replace(
+            seismogram,  # type: ignore[arg-type]
+            data=new_data,
+            begin_time=new_begin_time,
+        )
+
+    if padding_needed:
         seismogram.data = np.pad(
             seismogram.data,
             pad_width=(pad_before, pad_after),
@@ -340,23 +372,23 @@ def pad[T: Seismogram](
         )
         seismogram.begin_time += seismogram.delta * min(0, start_index)
 
-    return seismogram if clone else None
+    return None
 
 
 @overload
 def resample(
-    seismogram: Seismogram, delta: PositiveTimedelta, *, clone: Literal[False] = ...
+    seismogram: Seismogram, delta: PositiveTimedelta, *, replace: Literal[False] = ...
 ) -> None: ...
 
 
 @overload
 def resample[T: Seismogram](
-    seismogram: T, delta: PositiveTimedelta, *, clone: Literal[True]
+    seismogram: T, delta: PositiveTimedelta, *, replace: Literal[True]
 ) -> T: ...
 
 
 def resample[T: Seismogram](
-    seismogram: T, delta: PositiveTimedelta, *, clone: bool = False
+    seismogram: T, delta: PositiveTimedelta, *, replace: bool = False
 ) -> T | None:
     """Resample Seismogram data using the Fourier method.
 
@@ -367,10 +399,12 @@ def resample[T: Seismogram](
     Args:
         seismogram: Seismogram object.
         delta: New sampling interval.
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
 
     Returns:
-        Resampled [`Seismogram`][pysmo.Seismogram] object if called with `clone=True`.
+        Resampled [`Seismogram`][pysmo.Seismogram] object if called with `replace=True`.
 
     Examples:
         ```python
@@ -387,16 +421,27 @@ def resample[T: Seismogram](
         >>>
         ```
     """
-    if clone is True:
-        seismogram = deepcopy(seismogram)
+    if replace:
+        if delta != seismogram.delta:
+            npts = int(len(seismogram.data) * seismogram.delta / delta)
+            new_data = scipy.signal.resample(seismogram.data, npts)
+            new_delta = delta
+        else:
+            # replace=True must always hand back a fully independent object,
+            # even when the sampling interval is unchanged.
+            new_data = seismogram.data.copy()
+            new_delta = seismogram.delta
+        return copy.replace(
+            seismogram,  # type: ignore[arg-type]
+            data=new_data,
+            delta=new_delta,
+        )
 
     if delta != seismogram.delta:
         npts = int(len(seismogram.data) * seismogram.delta / delta)
         seismogram.data = scipy.signal.resample(seismogram.data, npts)
         seismogram.delta = delta
 
-    if clone is True:
-        return seismogram
     return None
 
 
@@ -449,7 +494,7 @@ def merge(
     delta: PositiveTimedelta | None = ...,
     auto_delta: Literal[False] = ...,
     gap_tolerance_factor: NonNegativeNumber = ...,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
 ) -> None: ...
 
 
@@ -460,7 +505,7 @@ def merge(
     delta: None = ...,
     auto_delta: Literal[True],
     gap_tolerance_factor: NonNegativeNumber = ...,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
 ) -> None: ...
 
 
@@ -471,7 +516,7 @@ def merge[T: Seismogram](
     delta: PositiveTimedelta | None = ...,
     auto_delta: Literal[False] = ...,
     gap_tolerance_factor: NonNegativeNumber = ...,
-    clone: Literal[True],
+    replace: Literal[True],
 ) -> T: ...
 
 
@@ -482,7 +527,7 @@ def merge[T: Seismogram](
     delta: None = ...,
     auto_delta: Literal[True],
     gap_tolerance_factor: NonNegativeNumber = ...,
-    clone: Literal[True],
+    replace: Literal[True],
 ) -> T: ...
 
 
@@ -492,7 +537,7 @@ def merge[T: Seismogram](
     delta: PositiveTimedelta | None = None,
     auto_delta: bool = False,
     gap_tolerance_factor: NonNegativeNumber = 0.5,
-    clone: bool = False,
+    replace: bool = False,
 ) -> T | None:
     """Merge contiguous seismograms into a single seismogram.
 
@@ -518,17 +563,19 @@ def merge[T: Seismogram](
     floating-point noise from e.g. prior resampling); they are verified and
     the duplicates are discarded rather than concatenated.
 
-    When `clone=False`, the first seismogram in `seismograms` (as given,
+    When `replace=False`, the first seismogram in `seismograms` (as given,
     not necessarily the chronologically first, and regardless of whether it
     is itself empty) is modified in place and becomes the merged result: its
     `begin_time` and `data` are overwritten to reflect the full,
     chronologically-ordered merge of the non-empty seismograms. Other input
-    seismograms are never modified.
+    seismograms are never modified. When `replace=True`, no input seismogram
+    is modified and a new merged seismogram is returned instead (not
+    supported by every concrete type; see [`pysmo.functions`][]).
 
     Args:
         seismograms: Seismograms to merge. May be given in any order; any mix
             of types satisfying the [`Seismogram`][pysmo.Seismogram] protocol
-            works at runtime. When `clone=True`, the return type is inferred
+            works at runtime. When `replace=True`, the return type is inferred
             from `seismograms`; for a bare list/tuple literal mixing concrete
             types, annotate it as `Sequence[Seismogram]` to keep the call
             type-checked (see Examples).
@@ -544,11 +591,13 @@ def merge[T: Seismogram](
             runtime too.
         gap_tolerance_factor: Maximum allowed boundary timestamp jitter between
             consecutive seismograms, as a fraction of the sampling interval.
-        clone: Operate on a clone of the first input seismogram.
+        replace: Return a new merged seismogram and leave every input
+            untouched, instead of modifying the first input in place. Not
+            supported by every concrete type (see [`pysmo.functions`][]).
 
     Returns:
         Merged [`Seismogram`][pysmo.Seismogram] object if called with
-        `clone=True`.
+        `replace=True`.
 
     Raises:
         ValueError: If both `delta` and `auto_delta` are given, `seismograms`
@@ -575,7 +624,7 @@ def merge[T: Seismogram](
         ...     delta=pd.Timedelta(seconds=1),
         ...     data=np.array([4.0, 5.0]),
         ... )
-        >>> merged = merge([first, second], clone=True)
+        >>> merged = merge([first, second], replace=True)
         >>> merged.data
         array([1., 2., 3., 4., 5.])
         >>> merged.begin_time
@@ -601,7 +650,7 @@ def merge[T: Seismogram](
         ...     sourceid="IU_ANMO_00_LHZ",
         ... )
         >>> mixed: Sequence[Seismogram] = [merged, geocsv_seis]
-        >>> merged_mixed = merge(mixed, clone=True)
+        >>> merged_mixed = merge(mixed, replace=True)
         >>> merged_mixed.data
         array([1., 2., 3., 4., 5., 6., 7.])
         >>>
@@ -630,7 +679,7 @@ def merge[T: Seismogram](
         ...     data=np.array([4.0, 5.0, 6.0]),
         ... )
         >>> auto_merged = merge(
-        ...     [steady, jittery], auto_delta=True, clone=True
+        ...     [steady, jittery], auto_delta=True, replace=True
         ... )
         >>> auto_merged.delta
         Timedelta('0 days 00:00:01')
@@ -657,11 +706,7 @@ def merge[T: Seismogram](
     if not seismograms:
         raise ValueError("No seismograms to merge.")
 
-    working = (
-        [deepcopy(seismogram) for seismogram in seismograms]
-        if clone
-        else list(seismograms)
-    )
+    working = list(seismograms)
 
     non_empty = [seismogram for seismogram in working if len(seismogram.data)]
     if not non_empty:
@@ -685,8 +730,8 @@ def merge[T: Seismogram](
                 continue
             if seismogram.delta == delta:
                 continue
-            if clone or index > 0:
-                working[index] = resample(seismogram, delta, clone=True)
+            if replace or index > 0:
+                working[index] = resample(seismogram, delta, replace=True)
             else:
                 resample(seismogram, delta)
         non_empty = [seismogram for seismogram in working if len(seismogram.data)]
@@ -720,10 +765,8 @@ def merge[T: Seismogram](
                 )
             overlap_samples[index] = samples
 
-    merged = cast(T, working[0])
-    merged.begin_time = ordered[0].begin_time
-    merged.delta = reference_delta
-    merged.data = np.concatenate(
+    merged_begin_time = ordered[0].begin_time
+    merged_data = np.concatenate(
         [ordered[0].data]
         + [
             seismogram.data[samples:]
@@ -731,8 +774,18 @@ def merge[T: Seismogram](
         ]
     )
 
-    if clone:
-        return merged
+    if replace:
+        return copy.replace(
+            working[0],  # type: ignore[arg-type]
+            data=merged_data,
+            begin_time=merged_begin_time,
+            delta=reference_delta,
+        )
+
+    merged = cast(T, working[0])
+    merged.begin_time = merged_begin_time
+    merged.delta = reference_delta
+    merged.data = merged_data
     return None
 
 
@@ -742,7 +795,7 @@ def taper(
     taper_width: NonNegativeTimedelta | UnitFloat,
     window_type: _WindowType = ...,
     *,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
 ) -> None: ...
 
 
@@ -752,7 +805,7 @@ def taper[T: Seismogram](
     taper_width: NonNegativeTimedelta | UnitFloat,
     window_type: _WindowType = ...,
     *,
-    clone: Literal[True],
+    replace: Literal[True],
 ) -> T: ...
 
 
@@ -761,7 +814,7 @@ def taper[T: Seismogram](
     taper_width: NonNegativeTimedelta | UnitFloat,
     window_type: _WindowType = "hann",
     *,
-    clone: bool = False,
+    replace: bool = False,
 ) -> T | None:
     """Apply a symmetric taper to the ends of a Seismogram.
 
@@ -797,10 +850,12 @@ def taper[T: Seismogram](
         taper_width: Width of the taper to use.
         window_type: Function to calculate taper shape (see
             [`get_window`][scipy.signal.windows.get_window] for valid inputs).
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
 
     Returns:
-        Tapered [`Seismogram`][pysmo.Seismogram] object if called with `clone=True`.
+        Tapered [`Seismogram`][pysmo.Seismogram] object if called with `replace=True`.
 
     Note: No taper below 2 samples
         If `taper_width` resolves to fewer than 2 samples, no taper is applied.
@@ -835,18 +890,17 @@ def taper[T: Seismogram](
             "'taper_width' is too large. Total taper width exceeds the duration of the seismogram."
         )
 
-    if clone is True:
-        seismogram = deepcopy(seismogram)
+    data = seismogram.data.copy() if replace else seismogram.data
 
     # Need at least 2 samples to apply a taper
     if nsamples >= 2:
         window = scipy.signal.windows.get_window(window_type, nsamples, fftbins=False)
         ramp_samples = nsamples // 2
-        seismogram.data[:ramp_samples] *= window[:ramp_samples]
-        seismogram.data[-ramp_samples:] *= window[-ramp_samples:]
+        data[:ramp_samples] *= window[:ramp_samples]
+        data[-ramp_samples:] *= window[-ramp_samples:]
 
-    if clone is True:
-        return seismogram
+    if replace:
+        return copy.replace(seismogram, data=data)  # type: ignore[arg-type]
     return None
 
 
@@ -912,7 +966,7 @@ def window(
     window_type: _WindowType = ...,
     same_shape: bool = False,
     *,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
 ) -> None: ...
 
 
@@ -925,7 +979,7 @@ def window[T: Seismogram](
     window_type: _WindowType = ...,
     *,
     same_shape: bool = False,
-    clone: Literal[True],
+    replace: Literal[True],
 ) -> T: ...
 
 
@@ -937,7 +991,7 @@ def window[T: Seismogram](
     window_type: _WindowType = "hann",
     same_shape: bool = False,
     *,
-    clone: bool = False,
+    replace: bool = False,
 ) -> T | None:
     """Return an optionally padded and tapered window of a seismogram.
 
@@ -970,10 +1024,12 @@ def window[T: Seismogram](
         window_type: Taper method to use (see [`taper`][pysmo.functions.taper]).
         same_shape: If True, pad the seismogram to its original length after
             windowing.
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
 
     Returns:
-        Windowed [`Seismogram`][pysmo.Seismogram] object if called with `clone=True`.
+        Windowed [`Seismogram`][pysmo.Seismogram] object if called with `replace=True`.
 
     Raises:
         ValueError: If `window_end_time` is not after `window_begin_time`, or
@@ -988,17 +1044,17 @@ def window[T: Seismogram](
 
         ```python
         >>> from pysmo.functions import window, detrend
-        >>> from pysmo.classes import SAC
+        >>> from pysmo.classes import MSeed
         >>> from pysmo.tools.plotutils import plotseis
         >>> import pandas as pd
         >>>
-        >>> sac_seis = SAC.from_file("example.sac").seismogram
+        >>> seis = MSeed.from_file("example.mseed")
         >>> ramp_width = pd.Timedelta(seconds=300)
-        >>> window_begin_time = sac_seis.begin_time + pd.Timedelta(seconds=600)
+        >>> window_begin_time = seis.begin_time + pd.Timedelta(seconds=600)
         >>> window_end_time = window_begin_time + pd.Timedelta(seconds=1200)
-        >>> windowed_seis = window(sac_seis, window_begin_time, window_end_time, ramp_width, same_shape=True, clone=True)
-        >>> detrend(sac_seis)
-        >>> fig = plotseis(sac_seis, windowed_seis)
+        >>> windowed_seis = window(seis, window_begin_time, window_end_time, ramp_width, same_shape=True, replace=True)
+        >>> detrend(seis)
+        >>> fig = plotseis(seis, windowed_seis)
         >>>
         ```
 
@@ -1008,11 +1064,11 @@ def window[T: Seismogram](
         >>> plt.close("all")
         >>> if savedir:
         ...     plt.style.use("dark_background")
-        ...     fig = plotseis(sac_seis, windowed_seis)
+        ...     fig = plotseis(seis, windowed_seis)
         ...     fig.savefig(savedir / "functions_window-dark.png", transparent=True)
         ...
         ...     plt.style.use("default")
-        ...     fig = plotseis(sac_seis, windowed_seis)
+        ...     fig = plotseis(seis, windowed_seis)
         ...     fig.savefig(savedir / "functions_window.png", transparent=True)
         >>>
         ```
@@ -1050,8 +1106,8 @@ def window[T: Seismogram](
     window_begin_time -= ramp_duration
     window_end_time += ramp_duration
 
-    if clone is True:
-        seismogram = crop(seismogram, window_begin_time, window_end_time, clone=True)
+    if replace:
+        seismogram = crop(seismogram, window_begin_time, window_end_time, replace=True)
     else:
         crop(seismogram, window_begin_time, window_end_time)
     detrend(seismogram)
@@ -1059,6 +1115,6 @@ def window[T: Seismogram](
     if same_shape is True:
         pad(seismogram, begin_time, end_time)
 
-    if clone is True:
+    if replace:
         return seismogram
     return None

--- a/src/pysmo/lib/io/_geocsv.py
+++ b/src/pysmo/lib/io/_geocsv.py
@@ -305,13 +305,13 @@ def merge_geocsv_timeseries(
             mini_seismograms,
             auto_delta=True,
             gap_tolerance_factor=gap_tolerance_factor,
-            clone=True,
+            replace=True,
         )
     else:
         merged = merge(
             mini_seismograms,
             gap_tolerance_factor=gap_tolerance_factor,
-            clone=True,
+            replace=True,
         )
     return _TimeseriesSegment(
         start_time=merged.begin_time,

--- a/src/pysmo/tools/project/__init__.py
+++ b/src/pysmo/tools/project/__init__.py
@@ -90,12 +90,11 @@ configurable per instance:
 ...         response = StationXML.fetch(
 ...             station=context.entry.station, time=context.starttime
 ...         ).response
-...         corrected = remove_response(
-...             seismogram, response, pre_filt=self.pre_filt, clone=True
+...         corrected = clone_to_mini(
+...             MiniIccsSeismogram, seismogram, update={"t0": context.predicted}
 ...         )
-...         return clone_to_mini(
-...             MiniIccsSeismogram, corrected, update={"t0": context.predicted}
-...         )
+...         remove_response(corrected, response, pre_filt=self.pre_filt)
+...         return corrected
 ...
 >>> to_mini_iccs_seismogram = ToMiniIccsSeismogramWithResponseRemoved(
 ...     # Teleseismic P on IU.ANMO's LHZ (1 Hz) channel: comfortably above

--- a/src/pysmo/tools/signal/__init__.py
+++ b/src/pysmo/tools/signal/__init__.py
@@ -13,9 +13,11 @@ Where a suitable implementation already exists in SciPy (e.g.
 reimplementing it; others implement seismology-specific algorithms with no
 direct SciPy equivalent.
 
-Functions that modify seismogram data follow the same `clone` convention as
-[`pysmo.functions`][]: without `clone` they operate in place
-and return `None`; with `clone=True` they return a modified copy.
+Functions that modify seismogram data follow the same `replace` convention as
+[`pysmo.functions`][]: without `replace` they operate in place and return
+`None`; with `replace=True` they leave the input untouched and return a new
+seismogram. Not every concrete type supports `replace=True`; see
+[`pysmo.functions`][] for how the new object is built and what carries over.
 
 !!! note "No unit tracking"
 

--- a/src/pysmo/tools/signal/_calculus.py
+++ b/src/pysmo/tools/signal/_calculus.py
@@ -1,6 +1,6 @@
 """Frequency-domain integration and differentiation."""
 
-from copy import deepcopy
+import copy
 from typing import Literal, overload
 
 import numpy as np
@@ -11,14 +11,14 @@ __all__ = ["differentiate", "integrate"]
 
 
 @overload
-def differentiate(seismogram: Seismogram, *, clone: Literal[False] = ...) -> None: ...
+def differentiate(seismogram: Seismogram, *, replace: Literal[False] = ...) -> None: ...
 
 
 @overload
-def differentiate[T: Seismogram](seismogram: T, *, clone: Literal[True]) -> T: ...
+def differentiate[T: Seismogram](seismogram: T, *, replace: Literal[True]) -> T: ...
 
 
-def differentiate[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | None:
+def differentiate[T: Seismogram](seismogram: T, *, replace: bool = False) -> T | None:
     r"""Differentiate a seismogram in the frequency domain.
 
     Multiplies the FFT of `seismogram.data` by $i\omega$ at each
@@ -30,11 +30,13 @@ def differentiate[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | N
 
     Args:
         seismogram: Seismogram object.
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
 
     Returns:
         Differentiated [`Seismogram`][pysmo.Seismogram] object if called with
-        `clone=True`.
+        `replace=True`.
 
     Raises:
         ValueError: If `seismogram.data` is empty.
@@ -58,7 +60,7 @@ def differentiate[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | N
         ...     delta=pd.Timedelta(seconds=dt),
         ...     data=np.sin(omega * t),
         ... )
-        >>> velocity = differentiate(seismogram, clone=True)
+        >>> velocity = differentiate(seismogram, replace=True)
         >>> expected = omega * np.cos(omega * t)
         >>> np.allclose(velocity.data, expected, atol=1e-6)
         True
@@ -70,9 +72,6 @@ def differentiate[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | N
     if seismogram.delta.total_seconds() <= 0:
         raise ValueError("Seismogram delta must be positive.")
 
-    if clone:
-        seismogram = deepcopy(seismogram)
-
     dt = seismogram.delta.total_seconds()
     npts = len(seismogram.data)
     freqs = np.fft.rfftfreq(npts, d=dt)
@@ -80,20 +79,24 @@ def differentiate[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | N
 
     spectrum = np.fft.rfft(seismogram.data)
     spectrum *= 1j * omega
-    seismogram.data = np.fft.irfft(spectrum, n=npts)
+    differentiated = np.fft.irfft(spectrum, n=npts)
 
-    return seismogram if clone else None
+    if replace:
+        return copy.replace(seismogram, data=differentiated)  # type: ignore[arg-type]
+
+    seismogram.data = differentiated
+    return None
 
 
 @overload
-def integrate(seismogram: Seismogram, *, clone: Literal[False] = ...) -> None: ...
+def integrate(seismogram: Seismogram, *, replace: Literal[False] = ...) -> None: ...
 
 
 @overload
-def integrate[T: Seismogram](seismogram: T, *, clone: Literal[True]) -> T: ...
+def integrate[T: Seismogram](seismogram: T, *, replace: Literal[True]) -> T: ...
 
 
-def integrate[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | None:
+def integrate[T: Seismogram](seismogram: T, *, replace: bool = False) -> T | None:
     r"""Integrate a seismogram in the frequency domain.
 
     Divides the FFT of `seismogram.data` by $i\omega$ at each
@@ -104,11 +107,13 @@ def integrate[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | None:
 
     Args:
         seismogram: Seismogram object.
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
 
     Returns:
         Integrated [`Seismogram`][pysmo.Seismogram] object if called with
-        `clone=True`.
+        `replace=True`.
 
     Raises:
         ValueError: If `seismogram.data` is empty.
@@ -132,7 +137,7 @@ def integrate[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | None:
         ...     delta=pd.Timedelta(seconds=dt),
         ...     data=omega * np.cos(omega * t),
         ... )
-        >>> displacement = integrate(seismogram, clone=True)
+        >>> displacement = integrate(seismogram, replace=True)
         >>> expected = np.sin(omega * t)
         >>> np.allclose(displacement.data, expected, atol=1e-6)
         True
@@ -144,9 +149,6 @@ def integrate[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | None:
     if seismogram.delta.total_seconds() <= 0:
         raise ValueError("Seismogram delta must be positive.")
 
-    if clone:
-        seismogram = deepcopy(seismogram)
-
     dt = seismogram.delta.total_seconds()
     npts = len(seismogram.data)
     freqs = np.fft.rfftfreq(npts, d=dt)
@@ -155,6 +157,10 @@ def integrate[T: Seismogram](seismogram: T, *, clone: bool = False) -> T | None:
     spectrum = np.fft.rfft(seismogram.data)
     integrated_spectrum = np.zeros_like(spectrum)
     integrated_spectrum[1:] = spectrum[1:] / (1j * omega[1:])
-    seismogram.data = np.fft.irfft(integrated_spectrum, n=npts)
+    integrated = np.fft.irfft(integrated_spectrum, n=npts)
 
-    return seismogram if clone else None
+    if replace:
+        return copy.replace(seismogram, data=integrated)  # type: ignore[arg-type]
+
+    seismogram.data = integrated
+    return None

--- a/src/pysmo/tools/signal/_filter/_butter.py
+++ b/src/pysmo/tools/signal/_filter/_butter.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+import copy
 from typing import Literal, overload
 
 from scipy.signal import iirfilter, sosfilt, sosfiltfilt
@@ -17,7 +17,7 @@ def bandpass(
     corners: PositiveInt = ...,
     zerophase: bool = ...,
     *,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
 ) -> None: ...
 
 
@@ -29,7 +29,7 @@ def bandpass[T: Seismogram](
     corners: PositiveInt = ...,
     zerophase: bool = ...,
     *,
-    clone: Literal[True],
+    replace: Literal[True],
 ) -> T: ...
 
 
@@ -41,7 +41,7 @@ def bandpass[T: Seismogram](
     corners: PositiveInt = 2,
     zerophase: bool = False,
     *,
-    clone: bool = False,
+    replace: bool = False,
 ) -> T | None:
     """Apply a bandpass filter to the input seismogram.
 
@@ -52,12 +52,13 @@ def bandpass[T: Seismogram](
         corners: The number of corners (poles) for the Butterworth filter.
         zerophase: If `True`, apply the filter in both forward and reverse
             directions to achieve zero phase distortion.
-        clone: If `True`, return a new Seismogram object with the filtered
-            data. If `False`, modify the input seismogram in place.
+        replace: If `True`, return a new Seismogram and leave the input
+            untouched. If `False`, modify the input seismogram in place. Not
+            supported by every concrete type (see [`pysmo.functions`][]).
 
     Returns:
         A new Seismogram containing the filtered data when called with
-        `clone=True`.
+        `replace=True`.
     """
     fe = 0.5 / seismogram.delta.total_seconds()
     low = freqmin / fe
@@ -76,15 +77,16 @@ def bandpass[T: Seismogram](
 
     sos = iirfilter(corners, [low, high], btype="band", ftype="butter", output="sos")
 
-    if clone:
-        seismogram = deepcopy(seismogram)
-
     if zerophase:
-        seismogram.data = sosfiltfilt(sos, seismogram.data)
+        filtered = sosfiltfilt(sos, seismogram.data)
     else:
-        seismogram.data = sosfilt(sos, seismogram.data)
+        filtered = sosfilt(sos, seismogram.data)
 
-    return seismogram if clone else None
+    if replace:
+        return copy.replace(seismogram, data=filtered)  # type: ignore[arg-type]
+
+    seismogram.data = filtered
+    return None
 
 
 def _zerophase_causal_ratio(corners: PositiveInt) -> float:
@@ -363,7 +365,7 @@ def highpass(
     corners: PositiveInt = ...,
     zerophase: bool = ...,
     *,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
 ) -> None: ...
 
 
@@ -374,7 +376,7 @@ def highpass[T: Seismogram](
     corners: PositiveInt = ...,
     zerophase: bool = ...,
     *,
-    clone: Literal[True],
+    replace: Literal[True],
 ) -> T: ...
 
 
@@ -385,7 +387,7 @@ def highpass[T: Seismogram](
     corners: PositiveInt = 2,
     zerophase: bool = False,
     *,
-    clone: bool = False,
+    replace: bool = False,
 ) -> T | None:
     """Apply a highpass filter to the input seismogram.
 
@@ -395,12 +397,13 @@ def highpass[T: Seismogram](
         corners: The number of corners (poles) for the Butterworth filter.
         zerophase: If `True`, apply the filter in both forward and reverse
             directions to achieve zero phase distortion.
-        clone: If `True`, return a new Seismogram object with the filtered
-            data. If `False`, modify the input seismogram in place.
+        replace: If `True`, return a new Seismogram and leave the input
+            untouched. If `False`, modify the input seismogram in place. Not
+            supported by every concrete type (see [`pysmo.functions`][]).
 
     Returns:
         A new Seismogram containing the filtered data when called with
-        `clone=True`.
+        `replace=True`.
     """
     fe = 0.5 / seismogram.delta.total_seconds()
     low = freqmin / fe
@@ -412,15 +415,16 @@ def highpass[T: Seismogram](
 
     sos = iirfilter(corners, low, btype="high", ftype="butter", output="sos")
 
-    if clone:
-        seismogram = deepcopy(seismogram)
-
     if zerophase:
-        seismogram.data = sosfiltfilt(sos, seismogram.data)
+        filtered = sosfiltfilt(sos, seismogram.data)
     else:
-        seismogram.data = sosfilt(sos, seismogram.data)
+        filtered = sosfilt(sos, seismogram.data)
 
-    return seismogram if clone else None
+    if replace:
+        return copy.replace(seismogram, data=filtered)  # type: ignore[arg-type]
+
+    seismogram.data = filtered
+    return None
 
 
 @overload
@@ -430,7 +434,7 @@ def lowpass(
     corners: PositiveInt = ...,
     zerophase: bool = ...,
     *,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
 ) -> None: ...
 
 
@@ -441,7 +445,7 @@ def lowpass[T: Seismogram](
     corners: PositiveInt = ...,
     zerophase: bool = ...,
     *,
-    clone: Literal[True],
+    replace: Literal[True],
 ) -> T: ...
 
 
@@ -452,7 +456,7 @@ def lowpass[T: Seismogram](
     corners: PositiveInt = 2,
     zerophase: bool = False,
     *,
-    clone: bool = False,
+    replace: bool = False,
 ) -> T | None:
     """Apply a lowpass filter to the input seismogram.
 
@@ -462,12 +466,13 @@ def lowpass[T: Seismogram](
         corners: The number of corners (poles) for the Butterworth filter.
         zerophase: If `True`, apply the filter in both forward and reverse
             directions to achieve zero phase distortion.
-        clone: If `True`, return a new Seismogram object with the filtered
-            data. If `False`, modify the input seismogram in place.
+        replace: If `True`, return a new Seismogram and leave the input
+            untouched. If `False`, modify the input seismogram in place. Not
+            supported by every concrete type (see [`pysmo.functions`][]).
 
     Returns:
         A new Seismogram containing the filtered data when called with
-        `clone=True`.
+        `replace=True`.
     """
     fe = 0.5 / seismogram.delta.total_seconds()
     high = freqmax / fe
@@ -479,15 +484,16 @@ def lowpass[T: Seismogram](
 
     sos = iirfilter(corners, high, btype="low", ftype="butter", output="sos")
 
-    if clone:
-        seismogram = deepcopy(seismogram)
-
     if zerophase:
-        seismogram.data = sosfiltfilt(sos, seismogram.data)
+        filtered = sosfiltfilt(sos, seismogram.data)
     else:
-        seismogram.data = sosfilt(sos, seismogram.data)
+        filtered = sosfilt(sos, seismogram.data)
 
-    return seismogram if clone else None
+    if replace:
+        return copy.replace(seismogram, data=filtered)  # type: ignore[arg-type]
+
+    seismogram.data = filtered
+    return None
 
 
 @overload
@@ -498,7 +504,7 @@ def bandstop(
     corners: PositiveInt = ...,
     zerophase: bool = ...,
     *,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
 ) -> None: ...
 
 
@@ -510,7 +516,7 @@ def bandstop[T: Seismogram](
     corners: PositiveInt = ...,
     zerophase: bool = ...,
     *,
-    clone: Literal[True],
+    replace: Literal[True],
 ) -> T: ...
 
 
@@ -522,7 +528,7 @@ def bandstop[T: Seismogram](
     corners: PositiveInt = 2,
     zerophase: bool = False,
     *,
-    clone: bool = False,
+    replace: bool = False,
 ) -> T | None:
     """Apply a bandstop filter to the input seismogram.
 
@@ -533,12 +539,13 @@ def bandstop[T: Seismogram](
         corners: The number of corners (poles) for the Butterworth filter.
         zerophase: If `True`, apply the filter in both forward and reverse
             directions to achieve zero phase distortion.
-        clone: If `True`, return a new Seismogram object with the filtered
-            data. If `False`, modify the input seismogram in place.
+        replace: If `True`, return a new Seismogram and leave the input
+            untouched. If `False`, modify the input seismogram in place. Not
+            supported by every concrete type (see [`pysmo.functions`][]).
 
     Returns:
         A new Seismogram containing the filtered data when called with
-        `clone=True`.
+        `replace=True`.
     """
     fe = 0.5 / seismogram.delta.total_seconds()
     low = freqmin / fe
@@ -559,12 +566,13 @@ def bandstop[T: Seismogram](
         corners, [low, high], btype="bandstop", ftype="butter", output="sos"
     )
 
-    if clone:
-        seismogram = deepcopy(seismogram)
-
     if zerophase:
-        seismogram.data = sosfiltfilt(sos, seismogram.data)
+        filtered = sosfiltfilt(sos, seismogram.data)
     else:
-        seismogram.data = sosfilt(sos, seismogram.data)
+        filtered = sosfilt(sos, seismogram.data)
 
-    return seismogram if clone else None
+    if replace:
+        return copy.replace(seismogram, data=filtered)  # type: ignore[arg-type]
+
+    seismogram.data = filtered
+    return None

--- a/src/pysmo/tools/signal/_filter/_filter.py
+++ b/src/pysmo/tools/signal/_filter/_filter.py
@@ -17,7 +17,7 @@ def filter(
     seismogram: Seismogram,
     filter_name: FilterName,
     *,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
     **filter_options: bool | int | float,
 ) -> None: ...
 
@@ -27,7 +27,7 @@ def filter[T: Seismogram](
     seismogram: T,
     filter_name: FilterName,
     *,
-    clone: Literal[True],
+    replace: Literal[True],
     **filter_options: bool | int | float,
 ) -> T: ...
 
@@ -36,7 +36,7 @@ def filter[T: Seismogram](
     seismogram: T,
     filter_name: FilterName,
     *,
-    clone: bool = False,
+    replace: bool = False,
     **filter_options: bool | int | float,
 ) -> T | None:
     """Apply a specified filter to the input seismogram.
@@ -46,26 +46,27 @@ def filter[T: Seismogram](
     Args:
         seismogram: The input seismogram to be filtered.
         filter_name: The type of filter to apply.
-        clone: If `True`, return a new Seismogram object with the filtered
-            data. If `False`, modify the input seismogram in place.
+        replace: If `True`, return a new Seismogram and leave the input
+            untouched. If `False`, modify the input seismogram in place. Not
+            supported by every concrete type (see [`pysmo.functions`][]).
         **filter_options: Filter parameters passed to the specified filter
             function.
 
     Returns:
         A new Seismogram containing the filtered data when called with
-        `clone=True`.
+        `replace=True`.
 
     Raises:
         ValueError: If `filter_name` is not a registered filter.
 
     Examples:
         ```python
-        >>> from pysmo.classes import SAC
+        >>> from pysmo.classes import MSeed
         >>> from pysmo.tools.signal import filter
-        >>> seis = SAC.from_file("example.sac").seismogram
+        >>> seis = MSeed.from_file("example.mseed")
         >>>
         >>> # create a new filtered seismogram with a lowpass filter
-        >>> filtered_seis = filter(seis, "lowpass", freqmax=0.5, clone=True)
+        >>> filtered_seis = filter(seis, "lowpass", freqmax=0.5, replace=True)
         >>>
         >>> # or update in place with a bandpass filter
         >>> filter(seis, "bandpass", freqmin=0.1, freqmax=0.5)
@@ -83,7 +84,7 @@ def filter[T: Seismogram](
             f"Filter '{filter_name}' is not registered. Available: {valid_filters}"
         ) from None
 
-    if clone:
-        return filter_func(seismogram, clone=True, **filter_options)
-    filter_func(seismogram, clone=False, **filter_options)
+    if replace:
+        return filter_func(seismogram, replace=True, **filter_options)
+    filter_func(seismogram, replace=False, **filter_options)
     return None

--- a/src/pysmo/tools/signal/_filter/_gauss.py
+++ b/src/pysmo/tools/signal/_filter/_gauss.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+import copy
 from typing import Literal, overload
 
 import numpy as np
@@ -11,19 +11,19 @@ from ._registry import register_filter
 
 @overload
 def envelope(
-    seismogram: Seismogram, fc: float, alpha: float, *, clone: Literal[False] = ...
+    seismogram: Seismogram, fc: float, alpha: float, *, replace: Literal[False] = ...
 ) -> None: ...
 
 
 @overload
 def envelope[T: Seismogram](
-    seismogram: T, fc: float, alpha: float, *, clone: Literal[True]
+    seismogram: T, fc: float, alpha: float, *, replace: Literal[True]
 ) -> T: ...
 
 
 @register_filter
 def envelope[T: Seismogram](
-    seismogram: T, fc: float, alpha: float, *, clone: bool = False
+    seismogram: T, fc: float, alpha: float, *, replace: bool = False
 ) -> T | None:
     """Calculate the envelope of a Gaussian-filtered seismogram.
 
@@ -32,7 +32,9 @@ def envelope[T: Seismogram](
         fc: Centre frequency of the Gaussian filter (in Hz).
         alpha: Dimensionless shape parameter controlling the filter width.
             Larger values produce a narrower (more selective) filter.
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
 
     Returns:
         Seismogram containing the envelope.
@@ -43,36 +45,37 @@ def envelope[T: Seismogram](
 
     Examples:
         ```python
-        >>> from pysmo.classes import SAC
+        >>> from pysmo.classes import MSeed
         >>> from pysmo.tools.signal import envelope
-        >>> seis = SAC.from_file("example.sac").seismogram
+        >>> seis = MSeed.from_file("example.mseed")
         >>> fc = 0.02 # Centre Gaussian filter at 0.02 Hz (50s period)
         >>> alpha = 50 # Set alpha (which determines filterwidth) to 50
-        >>> envelope_seis = envelope(seis, fc, alpha, clone=True)
+        >>> envelope_seis = envelope(seis, fc, alpha, replace=True)
         >>>
         ```
     """
-    if clone:
-        seismogram = deepcopy(seismogram)
-    seismogram.data = _gauss(seismogram, fc, alpha)[0]
-    return seismogram if clone else None
+    envelope_data = _gauss(seismogram, fc, alpha)[0]
+    if replace:
+        return copy.replace(seismogram, data=envelope_data)  # type: ignore[arg-type]
+    seismogram.data = envelope_data
+    return None
 
 
 @overload
 def gauss(
-    seismogram: Seismogram, fc: float, alpha: float, *, clone: Literal[False] = ...
+    seismogram: Seismogram, fc: float, alpha: float, *, replace: Literal[False] = ...
 ) -> None: ...
 
 
 @overload
 def gauss[T: Seismogram](
-    seismogram: T, fc: float, alpha: float, *, clone: Literal[True]
+    seismogram: T, fc: float, alpha: float, *, replace: Literal[True]
 ) -> T: ...
 
 
 @register_filter
 def gauss[T: Seismogram](
-    seismogram: T, fc: float, alpha: float, *, clone: bool = False
+    seismogram: T, fc: float, alpha: float, *, replace: bool = False
 ) -> T | None:
     """Return a Gaussian-filtered seismogram.
 
@@ -81,7 +84,9 @@ def gauss[T: Seismogram](
         fc: Centre frequency of the Gaussian filter (in Hz).
         alpha: Dimensionless shape parameter controlling the filter width.
             Larger values produce a narrower (more selective) filter.
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
 
     Returns:
         Gaussian-filtered seismogram.
@@ -92,19 +97,20 @@ def gauss[T: Seismogram](
 
     Examples:
         ```python
-        >>> from pysmo.classes import SAC
+        >>> from pysmo.classes import MSeed
         >>> from pysmo.tools.signal import gauss
-        >>> seis = SAC.from_file("example.sac").seismogram
+        >>> seis = MSeed.from_file("example.mseed")
         >>> fc = 0.02 # Centre Gaussian filter at 0.02 Hz (50s period)
         >>> alpha = 50 # Set alpha (which determines filterwidth) to 50
-        >>> gauss_seis = gauss(seis, fc, alpha, clone=True)
+        >>> gauss_seis = gauss(seis, fc, alpha, replace=True)
         >>>
         ```
     """
-    if clone:
-        seismogram = deepcopy(seismogram)
-    seismogram.data = _gauss(seismogram, fc, alpha)[1]
-    return seismogram if clone else None
+    gauss_data = _gauss(seismogram, fc, alpha)[1]
+    if replace:
+        return copy.replace(seismogram, data=gauss_data)  # type: ignore[arg-type]
+    seismogram.data = gauss_data
+    return None
 
 
 def _gauss(

--- a/src/pysmo/tools/signal/_filter/_registry.py
+++ b/src/pysmo/tools/signal/_filter/_registry.py
@@ -12,7 +12,7 @@ class SeismogramFilter(Protocol):
         self,
         seismogram: Seismogram,
         *args: Any,
-        clone: Literal[False] = ...,
+        replace: Literal[False] = ...,
         **kwargs: Any,
     ) -> None: ...
 
@@ -21,7 +21,7 @@ class SeismogramFilter(Protocol):
         self,
         seismogram: T,
         *args: Any,
-        clone: Literal[True],
+        replace: Literal[True],
         **kwargs: Any,
     ) -> T: ...
 
@@ -29,7 +29,7 @@ class SeismogramFilter(Protocol):
         self,
         seismogram: Seismogram,
         *args: Any,
-        clone: bool = False,
+        replace: bool = False,
         **kwargs: Any,
     ) -> Seismogram | None: ...
 

--- a/src/pysmo/tools/signal/_response.py
+++ b/src/pysmo/tools/signal/_response.py
@@ -1,7 +1,7 @@
 """Instrument response removal."""
 
+import copy
 import warnings
-from copy import deepcopy
 from typing import Literal, TypeIs, cast, overload
 
 import numpy as np
@@ -75,7 +75,7 @@ def remove_response(
     response: Response,
     pre_filt: tuple[float, float, float, float] | None = ...,
     *,
-    clone: Literal[False] = ...,
+    replace: Literal[False] = ...,
 ) -> None: ...
 
 
@@ -85,7 +85,7 @@ def remove_response[T: Seismogram](
     response: Response,
     pre_filt: tuple[float, float, float, float] | None = ...,
     *,
-    clone: Literal[True],
+    replace: Literal[True],
 ) -> T: ...
 
 
@@ -94,7 +94,7 @@ def remove_response[T: Seismogram](
     response: Response,
     pre_filt: tuple[float, float, float, float] | None = None,
     *,
-    clone: bool = False,
+    replace: bool = False,
 ) -> T | None:
     r"""Remove an instrument response from a seismogram.
 
@@ -193,11 +193,13 @@ def remove_response[T: Seismogram](
             `response.reference_sensitivity` in the time domain (see above).
             Not derived automatically; see Examples for how to choose a
             starting point.
-        clone: Operate on a clone of the input seismogram.
+        replace: Return a new seismogram and leave the input untouched,
+            instead of modifying it in place. Not supported by every
+            concrete type (see [`pysmo.functions`][]).
 
     Returns:
         Processed [`Seismogram`][pysmo.Seismogram] object if called with
-        `clone=True`.
+        `replace=True`.
 
     Raises:
         ValueError: If `seismogram.data` is empty; if `pre_filt` is `None`
@@ -225,7 +227,7 @@ def remove_response[T: Seismogram](
             of its actual roll-off.
 
     Examples:
-        The examples below build on the same setup: `example.sac`'s own real
+        The examples below build on the same setup: `example.mseed`'s own real
         response: a broadband seismometer and digitiser, from a genuine StationXML
         document for the actual station and epoch that recorded it.
 
@@ -233,12 +235,12 @@ def remove_response[T: Seismogram](
 
         ```python
         >>> from pathlib import Path
-        >>> from pysmo.classes import SAC, StationXML
+        >>> from pysmo.classes import MSeed, StationXML
         >>> from pysmo.tools.signal import remove_response
         >>> xml = Path("example_response.xml").read_bytes()
-        >>> original = SAC.from_file("example.sac").seismogram
+        >>> original = MSeed.from_file("example.mseed")
         >>> response = StationXML.from_bytes(xml, time=original.begin_time).response
-        >>> seismogram = remove_response(original, response, clone=True)
+        >>> seismogram = remove_response(original, response, replace=True)
         >>> len(seismogram.data) == len(original.data)
         True
         >>>
@@ -261,9 +263,9 @@ def remove_response[T: Seismogram](
         >>> f1 = min(abs(pole) for pole in response.poles if pole != 0) / 10
         >>> f2 = f1 * 10
         >>> pre_filt = (f1, f2, f3, f4)
-        >>> prepped = detrend(original, clone=True)
+        >>> prepped = detrend(original, replace=True)
         >>> taper(prepped, 0.05)
-        >>> deconvolved = remove_response(prepped, response, pre_filt=pre_filt, clone=True)
+        >>> deconvolved = remove_response(prepped, response, pre_filt=pre_filt, replace=True)
         >>> len(deconvolved.data) == len(original.data)
         True
         >>>
@@ -287,7 +289,7 @@ def remove_response[T: Seismogram](
 
         ```python
         >>> import numpy as np
-        >>> gain_only = remove_response(prepped, response, clone=True)
+        >>> gain_only = remove_response(prepped, response, replace=True)
         >>> gain_only_rms = np.sqrt(np.mean(gain_only.data**2))
         >>> deconvolved_rms = np.sqrt(np.mean(deconvolved.data**2))
         >>> round(float(gain_only_rms / deconvolved_rms), 3)  # ~1: amplitude match
@@ -356,10 +358,11 @@ def remove_response[T: Seismogram](
                 + "InstrumentSensitivity/Value) or pass pre_filt for full "
                 + "spectral deconvolution, which only needs overall_sensitivity."
             )
-        if clone:
-            seismogram = deepcopy(seismogram)
-        seismogram.data = seismogram.data / response.reference_sensitivity
-        return seismogram if clone else None
+        scaled = seismogram.data / response.reference_sensitivity
+        if replace:
+            return copy.replace(seismogram, data=scaled)  # type: ignore[arg-type]
+        seismogram.data = scaled
+        return None
 
     dt = seismogram.delta.total_seconds()
     if dt <= 0:
@@ -382,9 +385,6 @@ def remove_response[T: Seismogram](
             f"pre_filt's upper corner ({f4}) exceeds the seismogram's "
             + f"Nyquist frequency ({nyquist})."
         )
-
-    if clone:
-        seismogram = deepcopy(seismogram)
 
     freqs = np.fft.rfftfreq(len(seismogram.data), d=dt)
 
@@ -433,6 +433,10 @@ def remove_response[T: Seismogram](
     )
 
     spectrum = np.fft.rfft(seismogram.data)
-    seismogram.data = np.fft.irfft(spectrum * filt, n=len(seismogram.data))
+    deconvolved = np.fft.irfft(spectrum * filt, n=len(seismogram.data))
 
-    return seismogram if clone else None
+    if replace:
+        return copy.replace(seismogram, data=deconvolved)  # type: ignore[arg-type]
+
+    seismogram.data = deconvolved
+    return None

--- a/tests/functions/test_replace_contract.py
+++ b/tests/functions/test_replace_contract.py
@@ -1,0 +1,121 @@
+"""Direct coverage of the `replace` keyword contract.
+
+`replace=True` returns a new, fully independent seismogram of the same
+concrete type for value objects, and raises `TypeError` for `SacSeismogram`
+(a live projection of an open SAC file, not a value object). `replace=False`
+keeps the historical in-place behaviour.
+"""
+
+from copy import deepcopy
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pysmo import Seismogram
+from pysmo.classes import SacSeismogram
+from pysmo.functions import crop, detrend, normalize, pad, resample, taper
+
+VALUE_OBJECT_FIXTURES = ["mini_seismogram", "geocsv_seismogram", "mseed_seismogram"]
+
+
+@pytest.fixture(params=VALUE_OBJECT_FIXTURES, ids=VALUE_OBJECT_FIXTURES)
+def value_seismogram(request: pytest.FixtureRequest) -> Seismogram:
+    return request.getfixturevalue(request.param)
+
+
+class TestReplaceReturnsIndependentObject:
+    def test_same_concrete_type(self, value_seismogram: Seismogram) -> None:
+        result = detrend(value_seismogram, replace=True)
+        assert type(result) is type(value_seismogram)
+
+    def test_input_untouched(self, value_seismogram: Seismogram) -> None:
+        original = deepcopy(value_seismogram)
+        detrend(value_seismogram, replace=True)
+        np.testing.assert_array_equal(value_seismogram.data, original.data)
+        assert value_seismogram.begin_time == original.begin_time
+        assert value_seismogram.delta == original.delta
+
+    def test_returned_data_is_not_aliased(self, value_seismogram: Seismogram) -> None:
+        original = value_seismogram.data.copy()
+        result = detrend(value_seismogram, replace=True)
+        result.data[:] = 0.0
+        np.testing.assert_array_equal(value_seismogram.data, original)
+
+
+class TestReplaceUnsupportedForProjection:
+    def test_detrend_raises(self, sac_seismogram: SacSeismogram) -> None:
+        with pytest.raises(TypeError):
+            detrend(sac_seismogram, replace=True)
+
+    def test_crop_raises(self, sac_seismogram: SacSeismogram) -> None:
+        begin = sac_seismogram.begin_time + pd.Timedelta(seconds=1)
+        end = sac_seismogram.end_time - pd.Timedelta(seconds=1)
+        with pytest.raises(TypeError):
+            crop(sac_seismogram, begin, end, replace=True)
+
+    def test_input_not_mutated_when_raising(
+        self, sac_seismogram: SacSeismogram
+    ) -> None:
+        original = sac_seismogram.data.copy()
+        with pytest.raises(TypeError):
+            detrend(sac_seismogram, replace=True)
+        np.testing.assert_array_equal(sac_seismogram.data, original)
+
+
+class TestReplaceFalseUnchanged:
+    def test_in_place_returns_none_and_mutates(
+        self, value_seismogram: Seismogram
+    ) -> None:
+        before = value_seismogram.data.copy()
+        result = detrend(value_seismogram)
+        assert result is None
+        assert not np.array_equal(value_seismogram.data, before)
+
+
+class TestNoAliasGuarantee:
+    def test_crop_slice_is_copied(self, value_seismogram: Seismogram) -> None:
+        begin = value_seismogram.begin_time + 5 * value_seismogram.delta
+        end = value_seismogram.end_time - 5 * value_seismogram.delta
+        original = value_seismogram.data.copy()
+        cropped = crop(value_seismogram, begin, end, replace=True)
+        cropped.data[:] = 0.0
+        np.testing.assert_array_equal(value_seismogram.data, original)
+
+    def test_taper_starts_from_a_copy(self, value_seismogram: Seismogram) -> None:
+        original = value_seismogram.data.copy()
+        tapered = taper(value_seismogram, 0.2, replace=True)
+        tapered.data[:] = 0.0
+        np.testing.assert_array_equal(value_seismogram.data, original)
+
+
+class TestNoOpBranchesStillCopy:
+    def test_pad_no_op_returns_independent_copy(
+        self, value_seismogram: Seismogram
+    ) -> None:
+        original = value_seismogram.data.copy()
+        padded = pad(
+            value_seismogram,
+            value_seismogram.begin_time,
+            value_seismogram.end_time,
+            replace=True,
+        )
+        assert len(padded.data) == len(value_seismogram.data)
+        padded.data[:] = 0.0
+        np.testing.assert_array_equal(value_seismogram.data, original)
+
+    def test_resample_no_op_returns_independent_copy(
+        self, value_seismogram: Seismogram
+    ) -> None:
+        original = value_seismogram.data.copy()
+        resampled = resample(value_seismogram, value_seismogram.delta, replace=True)
+        assert len(resampled.data) == len(value_seismogram.data)
+        resampled.data[:] = 0.0
+        np.testing.assert_array_equal(value_seismogram.data, original)
+
+
+def test_normalize_replace_matches_in_place(value_seismogram: Seismogram) -> None:
+    in_place = deepcopy(value_seismogram)
+    replaced = normalize(value_seismogram, replace=True)
+    normalize(in_place)
+    np.testing.assert_array_equal(replaced.data, in_place.data)

--- a/tests/functions/test_seismogram.py
+++ b/tests/functions/test_seismogram.py
@@ -11,6 +11,7 @@ from matplotlib.figure import Figure
 from syrupy.assertion import SnapshotAssertion
 
 from pysmo import MiniSeismogram, Seismogram
+from pysmo.classes import SacSeismogram
 from pysmo.functions._seismogram import _WindowType
 from pysmo.tools.plotutils import time_array
 from tests.conftest import contiguous_seismogram_pairs, mini_seismograms
@@ -51,9 +52,9 @@ def test_normalize(seismogram: Seismogram) -> None:
 
     normalized_seis.data[:10] += 3
     normalized_seis.data[-10:] += 3
-    normalized_seis2 = normalize(
-        normalized_seis,
-        clone=True,
+    normalized_seis2 = deepcopy(normalized_seis)
+    normalize(
+        normalized_seis2,
         t1=normalized_seis.begin_time + 10 * normalized_seis.delta,
         t2=normalized_seis.end_time - 10 * normalized_seis.delta,
     )
@@ -276,11 +277,11 @@ def test_merge_auto_delta_resamples_jittery_deltas() -> None:
         data=np.array([4.0, 5.0, 6.0]),
     )
 
-    merged = merge([first, second], auto_delta=True, clone=True)
+    merged = merge([first, second], auto_delta=True, replace=True)
     assert merged.delta == pd.Timedelta(seconds=1)
     np.testing.assert_allclose(merged.data, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
 
-    # Neither input is mutated when clone=True.
+    # Neither input is mutated when replace=True.
     assert second.delta == pd.Timedelta(seconds=1) + pd.Timedelta(nanoseconds=1)
 
 
@@ -299,7 +300,7 @@ def test_merge() -> None:
         data=np.array([4.0, 5.0]),
     )
 
-    merged = merge([first, second], clone=True)
+    merged = merge([first, second], replace=True)
     np.testing.assert_array_equal(merged.data, np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
     assert merged.begin_time == first.begin_time
     assert merged.delta == first.delta
@@ -326,11 +327,11 @@ def test_merge_out_of_order_input() -> None:
     )
 
     # `second` is passed first, even though `first` starts earlier.
-    merged = merge([second, first], clone=True)
+    merged = merge([second, first], replace=True)
     np.testing.assert_array_equal(merged.data, np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
     assert merged.begin_time == first.begin_time
 
-    # clone=False still mutates and returns the literal first list entry
+    # replace=False still mutates and returns the literal first list entry
     # (`second`), even though it is not chronologically first.
     result = merge([second, first])
     assert result is None
@@ -361,7 +362,7 @@ def test_merge_empty_seismogram_discarded() -> None:
         data=np.array([4.0, 5.0]),
     )
 
-    merged = merge([first, empty, second], clone=True)
+    merged = merge([first, empty, second], replace=True)
     np.testing.assert_array_equal(merged.data, np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
     assert merged.begin_time == first.begin_time
 
@@ -386,15 +387,15 @@ def test_merge_first_empty_is_still_mutation_target() -> None:
         data=np.array([4.0, 5.0]),
     )
 
-    # clone=True: the clone is based on `empty` (the first list entry),
-    # even though it started out empty.
-    merged = merge([empty, first, second], clone=True)
+    # replace=True: the new object is based on `empty` (the first list
+    # entry), even though it started out empty.
+    merged = merge([empty, first, second], replace=True)
     np.testing.assert_array_equal(merged.data, np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
     assert merged.begin_time == first.begin_time
     assert merged.delta == first.delta
     assert empty.data.size == 0  # the original `empty` object is untouched
 
-    # clone=False: `empty` itself is mutated in place and becomes the
+    # replace=False: `empty` itself is mutated in place and becomes the
     # merged result, even though it started out empty.
     result = merge([empty, first, second])
     assert result is None
@@ -445,7 +446,7 @@ def test_merge_with_resampling() -> None:
         data=np.full(8, 2.0),
     )
 
-    merged = merge([first, second], delta=pd.Timedelta(seconds=1), clone=True)
+    merged = merge([first, second], delta=pd.Timedelta(seconds=1), replace=True)
     np.testing.assert_allclose(
         merged.data, np.array([1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0])
     )
@@ -453,7 +454,7 @@ def test_merge_with_resampling() -> None:
     assert second.delta == pd.Timedelta(milliseconds=500)
 
 
-def test_merge_with_resampling_no_clone() -> None:
+def test_merge_with_resampling_in_place() -> None:
     from pysmo import MiniSeismogram
     from pysmo.functions import merge
 
@@ -536,7 +537,7 @@ def test_merge_allows_tiny_boundary_jitter() -> None:
         data=np.full(2, 2.0),
     )
 
-    merged = merge([first, second], clone=True)
+    merged = merge([first, second], replace=True)
     np.testing.assert_array_equal(merged.data, np.array([1.0, 1.0, 1.0, 2.0, 2.0]))
 
 
@@ -557,7 +558,7 @@ def test_merge_matching_overlap_is_trimmed() -> None:
         data=np.array([3.0, 4.0, 5.0]),
     )
 
-    merged = merge([first, second], gap_tolerance_factor=1.0, clone=True)
+    merged = merge([first, second], gap_tolerance_factor=1.0, replace=True)
     np.testing.assert_array_equal(merged.data, np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
     assert merged.begin_time == first.begin_time
     assert merged.end_time == first.begin_time + merged.delta * 4
@@ -688,8 +689,14 @@ def test_crop(seismogram: Seismogram) -> None:
         seis3.data = seis3.data[:100]
         new_begin_time = seis3.begin_time + seis3.delta
         new_end_time = seis3.end_time - seis3.delta
-        cropped_seis = crop(seis3, new_begin_time, new_end_time, clone=True)
-        assert all(cropped_seis.data == seis3.data[1:-1])
+        try:
+            cropped_seis = crop(seis3, new_begin_time, new_end_time, replace=True)
+        except TypeError:
+            # replace=True is unsupported only for projection types
+            # (SacSeismogram); a TypeError from a value object is a real bug.
+            assert isinstance(seis3, SacSeismogram)
+        else:
+            assert all(cropped_seis.data == seis3.data[1:-1])
 
 
 def test_crop_snapshot(seismogram: Seismogram, snapshot: SnapshotAssertion) -> None:
@@ -715,14 +722,17 @@ def test_crop_snapshot(seismogram: Seismogram, snapshot: SnapshotAssertion) -> N
 class TestTaper:
     @pytest.mark.mpl_image_compare(remove_text=True)
     def test_taper(self, seismogram: Seismogram) -> Figure:
-        from pysmo.functions import taper
+        from pysmo.functions import clone_to_mini, taper
 
+        # replace=True is unsupported for SacSeismogram; exercise the taper
+        # behaviour on a value-object copy instead.
+        seismogram = clone_to_mini(MiniSeismogram, seismogram)
         seismogram.data = np.ones(len(seismogram.data))
 
         with pytest.raises(TypeError):
-            _ = taper(seismogram, "abc", clone=True)  # type: ignore
+            _ = taper(seismogram, "abc", replace=True)  # type: ignore
         with pytest.raises(ValueError):
-            _ = taper(seismogram, 1.7, clone=True)
+            _ = taper(seismogram, 1.7, replace=True)
         fig = plt.figure()
         time = time_array(seismogram)
         plt.plot(time, seismogram.data, scalex=True, scaley=True)
@@ -738,13 +748,13 @@ class TestTaper:
             ("general_hamming", 0.75),
         ]
         for method in methods:
-            seis_taper = taper(seismogram, 0.5, method, clone=True)
+            seis_taper = taper(seismogram, 0.5, method, replace=True)
             plt.plot(time, seis_taper.data, scalex=True, scaley=True)
             seis_taper = taper(
                 seismogram,
                 (seismogram.end_time - seismogram.begin_time) * 0.5,
                 method,
-                clone=True,
+                replace=True,
             )
             plt.plot(time, seis_taper.data, scalex=True, scaley=True)
         plt.xlabel("Time")
@@ -758,8 +768,11 @@ class TestWindow:
     TAPER_WIDTH: pd.Timedelta | float = pd.Timedelta(seconds=100)
 
     def test_window(self, seismogram: Seismogram) -> None:
-        from pysmo.functions import time2index, window
+        from pysmo.functions import clone_to_mini, time2index, window
 
+        # replace=True is unsupported for SacSeismogram; exercise window on a
+        # value-object copy instead.
+        seismogram = clone_to_mini(MiniSeismogram, seismogram)
         taper_width = self.TAPER_WIDTH
 
         window_begin_time = seismogram.begin_time + pd.Timedelta(seconds=150)
@@ -770,7 +783,7 @@ class TestWindow:
             window_end_time,
             taper_width,
             same_shape=True,
-            clone=True,
+            replace=True,
         )
         assert windowed_seis.begin_time.timestamp() == pytest.approx(
             seismogram.begin_time.timestamp()
@@ -888,7 +901,7 @@ def test_crop_randomised_window(seis: MiniSeismogram, k1: int, k2: int) -> None:
     t2 = seis.end_time - k2 * seis.delta
     assume(t1 <= t2)
 
-    cropped = crop(seis, t1, t2, clone=True)
+    cropped = crop(seis, t1, t2, replace=True)
     assert len(cropped.data) <= len(seis.data)
     assert cropped.begin_time >= t1
     assert cropped.end_time <= t2 + seis.delta
@@ -899,7 +912,7 @@ def test_crop_randomised_window(seis: MiniSeismogram, k1: int, k2: int) -> None:
 def test_crop_identity(seis: MiniSeismogram) -> None:
     from pysmo.functions import crop
 
-    cropped = crop(seis, seis.begin_time, seis.end_time, clone=True)
+    cropped = crop(seis, seis.begin_time, seis.end_time, replace=True)
     np.testing.assert_array_equal(cropped.data, seis.data)
     assert cropped.begin_time == seis.begin_time
     assert cropped.delta == seis.delta
@@ -911,7 +924,7 @@ def test_normalize_peak_is_one(seis: MiniSeismogram) -> None:
     from pysmo.functions import normalize
 
     assume(np.max(np.abs(seis.data)) > 1e-10)
-    result = normalize(seis, clone=True)
+    result = normalize(seis, replace=True)
     assert np.max(np.abs(result.data)) == pytest.approx(1.0)
 
 
@@ -931,8 +944,8 @@ def test_normalize_scaling_invariance(seis: MiniSeismogram, scalar: float) -> No
         delta=seis.delta,
         begin_time=seis.begin_time,
     )
-    norm1 = normalize(seis, clone=True)
-    norm2 = normalize(scaled_seis, clone=True)
+    norm1 = normalize(seis, replace=True)
+    norm2 = normalize(scaled_seis, replace=True)
     np.testing.assert_allclose(norm1.data, norm2.data, rtol=1e-5, atol=1e-8)
 
 
@@ -947,7 +960,7 @@ def test_pad_preserves_data(seis: MiniSeismogram, pre_pad: int, post_pad: int) -
 
     new_begin = seis.begin_time - pre_pad * seis.delta
     new_end = seis.end_time + post_pad * seis.delta
-    padded = pad(seis, new_begin, new_end, clone=True)
+    padded = pad(seis, new_begin, new_end, replace=True)
     assert len(padded.data) == len(seis.data) + pre_pad + post_pad
     # Original data sits at the exact pre_pad offset
     np.testing.assert_array_equal(
@@ -964,7 +977,7 @@ def test_merge_contiguous_data_conservation(
     from pysmo.functions import merge
 
     seis1, seis2 = pair
-    merged = merge([seis1, seis2], clone=True)
+    merged = merge([seis1, seis2], replace=True)
     assert merged is not None
     assert len(merged.data) == len(seis1.data) + len(seis2.data)
     np.testing.assert_array_equal(
@@ -983,8 +996,8 @@ def test_merge_chronological_sorting(
     from pysmo.functions import merge
 
     seis1, seis2 = pair
-    merged_forward = merge([seis1, seis2], clone=True)
-    merged_reversed = merge([seis2, seis1], clone=True)
+    merged_forward = merge([seis1, seis2], replace=True)
+    merged_reversed = merge([seis2, seis1], replace=True)
     assert merged_forward is not None and merged_reversed is not None
     np.testing.assert_array_equal(merged_forward.data, merged_reversed.data)
     assert merged_forward.begin_time == merged_reversed.begin_time
@@ -995,7 +1008,7 @@ def test_merge_chronological_sorting(
 def test_merge_single_input_identity(seis: MiniSeismogram) -> None:
     from pysmo.functions import merge
 
-    merged = merge([seis], clone=True)
+    merged = merge([seis], replace=True)
     assert merged is not None
     np.testing.assert_array_equal(merged.data, seis.data)
     assert merged.begin_time == seis.begin_time

--- a/tests/integration/test_response_removal_live.py
+++ b/tests/integration/test_response_removal_live.py
@@ -93,7 +93,7 @@ def test_remove_response_pipeline_live(
     assert epoch.channel == "BHZ"
     assert len(response.stages) > 0
 
-    prepped = detrend(seismogram, clone=True)
+    prepped = detrend(seismogram, replace=True)
     taper(prepped, 0.05)
 
     nyquist = 0.5 / prepped.delta.total_seconds()
@@ -104,8 +104,8 @@ def test_remove_response_pipeline_live(
     f2 = f1 * 10
     pre_filt = (f1, f2, f3, f4)
 
-    gain_only = remove_response(prepped, response, clone=True)
-    deconvolved = remove_response(prepped, response, pre_filt=pre_filt, clone=True)
+    gain_only = remove_response(prepped, response, replace=True)
+    deconvolved = remove_response(prepped, response, pre_filt=pre_filt, replace=True)
 
     assert np.all(np.isfinite(gain_only.data))
     assert np.all(np.isfinite(deconvolved.data))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -89,7 +89,8 @@ With keyword arguments:
         )
 
 The helper automatically:
-- Tests both clone=True and clone=False modes
+- Tests both replace=True and replace=False modes (replace=True skipped for
+  projection types such as SacSeismogram, which raise TypeError)
 - Verifies both produce identical results
 - Checks data arrays match using numpy.testing.assert_array_equal
 - Validates time attributes (begin_time, delta, length)
@@ -105,6 +106,7 @@ from typing import Any
 import numpy as np
 
 from pysmo import Seismogram
+from pysmo.classes import SacSeismogram
 
 try:
     from syrupy.assertion import SnapshotAssertion
@@ -123,13 +125,15 @@ def assert_seismogram_modification(
     snapshot_decimals: int = 6,
     **kwargs: Any,
 ) -> Seismogram:
-    """Test that a seismogram modification function works correctly with both clone modes.
+    """Test that a seismogram modification function works correctly with both replace modes.
 
     This helper function tests modification functions that support both:
-    1. clone=True: Returns a new modified Seismogram
-    2. clone=False (default): Modifies the Seismogram in-place
+    1. replace=True: Returns a new modified Seismogram, input untouched
+    2. replace=False (default): Modifies the Seismogram in-place
 
-    It verifies that both approaches produce identical results and runs any
+    For projection types (SacSeismogram) replace=True raises TypeError and
+    only the in-place branch is exercised. It verifies that both approaches
+    produce identical results and runs any
     custom assertions on the modified seismogram. Optionally compares against
     expected data using numpy array assertions with configurable tolerances or
     syrupy snapshot testing.
@@ -137,7 +141,7 @@ def assert_seismogram_modification(
     Args:
         seismogram: The input Seismogram to be modified (any implementation).
         modification_func: The function that modifies the seismogram.
-            Must accept the seismogram as first argument and support a 'clone'
+            Must accept the seismogram as first argument and support a 'replace'
             parameter.
         *args: Positional arguments to pass to modification_func (after seismogram).
         custom_assertions: Optional callback function that receives the modified
@@ -159,13 +163,14 @@ def assert_seismogram_modification(
             order 1e-4 or smaller) needs a higher value or 6 decimals rounds
             away most of the signal. Only used when expected_data is a
             SnapshotAssertion.
-        **kwargs: Keyword arguments to pass to modification_func (except 'clone').
+        **kwargs: Keyword arguments to pass to modification_func (except 'replace').
 
     Returns:
-        The cloned modified seismogram (result of calling with clone=True).
+        The modified seismogram (the replace=True result where supported,
+        otherwise the in-place result).
 
     Raises:
-        AssertionError: If clone and in-place modifications produce different results,
+        AssertionError: If replace and in-place modifications produce different results,
             if custom_assertions fail, or if expected_data comparison fails.
 
     Examples:
@@ -196,40 +201,60 @@ def assert_seismogram_modification(
         ...     expected_data=snapshot,  # syrupy snapshot fixture
         ... )
     """
-    # Test with clone=True - should return a new modified seismogram
-    cloned_modified = modification_func(seismogram, *args, clone=True, **kwargs)
-    assert cloned_modified is not None, (
-        "Function with clone=True should return a Seismogram"
-    )
+    # Test with replace=True - should return a new modified seismogram and
+    # leave the input untouched. Projection types (SacSeismogram) do not
+    # support replace=True and raise TypeError; those skip this branch. A
+    # TypeError from a value-object type is a real bug, not an expected skip.
+    original_copy = deepcopy(seismogram)
+    try:
+        replaced_modified = modification_func(seismogram, *args, replace=True, **kwargs)
+    except TypeError:
+        assert isinstance(seismogram, SacSeismogram), (
+            f"replace=True raised TypeError for {type(seismogram).__name__}, "
+            "which is not a projection type and should support it"
+        )
+        replaced_modified = None
+    else:
+        assert replaced_modified is not None, (
+            "Function with replace=True should return a Seismogram"
+        )
+        np.testing.assert_array_equal(
+            seismogram.data,
+            original_copy.data,
+            err_msg="replace=True modified the input seismogram",
+        )
 
-    # Test with clone=False (in-place) - should modify and return None or the seismogram
+    # Test with replace=False (in-place) - modifies and returns None
     inplace_copy = deepcopy(seismogram)
-    result = modification_func(inplace_copy, *args, clone=False, **kwargs)
+    result = modification_func(inplace_copy, *args, replace=False, **kwargs)
 
     # Handle functions that may return the seismogram or None
     inplace_modified = result if result is not None else inplace_copy
 
-    # Verify both approaches produce identical data
-    np.testing.assert_array_equal(
-        cloned_modified.data,
-        inplace_modified.data,
-        err_msg="Clone and in-place modifications produced different data",
-    )
+    if replaced_modified is not None:
+        # Verify both approaches produce identical data
+        np.testing.assert_array_equal(
+            replaced_modified.data,
+            inplace_modified.data,
+            err_msg="replace and in-place modifications produced different data",
+        )
 
-    # Verify time attributes match
-    assert cloned_modified.begin_time == inplace_modified.begin_time, (
-        "Clone and in-place modifications have different begin_time"
-    )
-    assert cloned_modified.delta == inplace_modified.delta, (
-        "Clone and in-place modifications have different delta"
-    )
-    assert len(cloned_modified.data) == len(inplace_modified.data), (
-        "Clone and in-place modifications have different lengths"
-    )
+        # Verify time attributes match
+        assert replaced_modified.begin_time == inplace_modified.begin_time, (
+            "replace and in-place modifications have different begin_time"
+        )
+        assert replaced_modified.delta == inplace_modified.delta, (
+            "replace and in-place modifications have different delta"
+        )
+        assert len(replaced_modified.data) == len(inplace_modified.data), (
+            "replace and in-place modifications have different lengths"
+        )
+
+    modified = replaced_modified if replaced_modified is not None else inplace_modified
 
     # Run custom assertions if provided
     if custom_assertions is not None:
-        custom_assertions(cloned_modified)
+        custom_assertions(modified)
 
     # Validate against expected data if provided
     if expected_data is not None:
@@ -239,12 +264,12 @@ def assert_seismogram_modification(
         ):
             # Use syrupy's assert_match method for snapshot comparison
             # Round data to reduce snapshot size and improve precision control
-            rounded_data = np.around(cloned_modified.data, decimals=snapshot_decimals)
+            rounded_data = np.around(modified.data, decimals=snapshot_decimals)
             expected_data.assert_match(rounded_data)
         elif isinstance(expected_data, np.ndarray):
             # Use numpy's assert_allclose for array comparison
             np.testing.assert_allclose(
-                cloned_modified.data,
+                modified.data,
                 expected_data,
                 rtol=rtol,
                 atol=atol,
@@ -253,11 +278,11 @@ def assert_seismogram_modification(
         else:
             # Fallback: try direct comparison (might be a list or other sequence)
             np.testing.assert_allclose(
-                cloned_modified.data,
+                modified.data,
                 expected_data,
                 rtol=rtol,
                 atol=atol,
                 err_msg="Modified data does not match expected data within tolerance",
             )
 
-    return cloned_modified
+    return modified

--- a/tests/tools/signal/filter/test_butter.py
+++ b/tests/tools/signal/filter/test_butter.py
@@ -1,7 +1,7 @@
 """Unit tests for Butterworth filter functions in _butter.py.
 
 This module tests the bandpass, highpass, lowpass, and bandstop filter functions.
-Each function is tested for both clone modes, parameter validation, and zerophase modes.
+Each function is tested for both replace modes, parameter validation, and zerophase modes.
 """
 
 import numpy as np
@@ -114,7 +114,7 @@ class TestBandpass(BaseButterFilterTest):
         """Test bandpass filter with default parameters.
 
         Verify that the bandpass filter correctly filters the data and that
-        both clone modes produce identical results.
+        both replace modes produce identical results.
         """
         freqmin = 0.1  # 0.1 Hz
         freqmax = 0.5  # 0.5 Hz
@@ -220,7 +220,7 @@ class TestHighpass(BaseButterFilterTest):
         """Test highpass filter with default parameters.
 
         Verify that the highpass filter correctly filters the data and that
-        both clone modes produce identical results.
+        both replace modes produce identical results.
         """
         freqmin = 0.1  # 0.1 Hz
         corners = 2
@@ -296,7 +296,7 @@ class TestLowpass(BaseButterFilterTest):
         """Test lowpass filter with default parameters.
 
         Verify that the lowpass filter correctly filters the data and that
-        both clone modes produce identical results.
+        both replace modes produce identical results.
         """
         freqmax = 0.5  # 0.5 Hz
         corners = 2
@@ -372,7 +372,7 @@ class TestBandstop(BaseButterFilterTest):
         """Test bandstop filter with default parameters.
 
         Verify that the bandstop filter correctly filters the data and that
-        both clone modes produce identical results.
+        both replace modes produce identical results.
         """
         freqmin = 0.1  # 0.1 Hz
         freqmax = 0.5  # 0.5 Hz

--- a/tests/tools/signal/filter/test_filter.py
+++ b/tests/tools/signal/filter/test_filter.py
@@ -1,7 +1,7 @@
 """Unit tests for the filter() convenience wrapper in _filter.py.
 
 This module tests that filter() correctly dispatches to registered filter
-functions, supports both clone modes, passes keyword arguments through, and
+functions, supports both replace modes, passes keyword arguments through, and
 raises ValueError for unregistered filter names.
 """
 

--- a/tests/tools/signal/filter/test_gauss.py
+++ b/tests/tools/signal/filter/test_gauss.py
@@ -84,9 +84,13 @@ def test_plot_gauss_env(sac_seismogram: Seismogram) -> matplotlib.figure.Figure:
     """Test plotting gauss and envelope functions."""
     fc = 0.02  # Centre Gaussian filter at 0.02 Hz (50s period)
     alpha = 50  # Set alpha (which determines filterwidth) to 50
-    seismogram = sac_seismogram
+    from pysmo import MiniSeismogram
+    from pysmo.functions import clone_to_mini
+
+    # replace=True is unsupported for SacSeismogram; use a value-object copy.
+    seismogram = clone_to_mini(MiniSeismogram, sac_seismogram)
     seismogram.data = seismogram.data - np.mean(seismogram.data)
-    gauss_seis = gauss(seismogram, fc, alpha, clone=True)
-    env_seis = envelope(seismogram, fc, alpha, clone=True)
+    gauss_seis = gauss(seismogram, fc, alpha, replace=True)
+    env_seis = envelope(seismogram, fc, alpha, replace=True)
     fig = plotseis(seismogram, gauss_seis, env_seis)
     return fig

--- a/tests/tools/signal/test_calculus.py
+++ b/tests/tools/signal/test_calculus.py
@@ -36,7 +36,7 @@ class TestDifferentiate:
         omega = 2 * np.pi * 1.0
         expected = omega * np.cos(omega * t)
 
-        result = differentiate(sine_seismogram, clone=True)
+        result = differentiate(sine_seismogram, replace=True)
         npt.assert_allclose(result.data, expected, atol=1e-6)
 
     def test_constant_offset_differentiates_to_zero(self, dt: float) -> None:
@@ -45,10 +45,10 @@ class TestDifferentiate:
             delta=pd.Timedelta(seconds=dt),
             data=np.full(64, 3.0),
         )
-        result = differentiate(seismogram, clone=True)
+        result = differentiate(seismogram, replace=True)
         npt.assert_allclose(result.data, 0.0, atol=1e-9)
 
-    def test_clone_matches_in_place(self, sine_seismogram: MiniSeismogram) -> None:
+    def test_replace_matches_in_place(self, sine_seismogram: MiniSeismogram) -> None:
         assert_seismogram_modification(sine_seismogram, differentiate)
 
     def test_empty_seismogram_raises(self, dt: float) -> None:
@@ -75,14 +75,14 @@ class TestIntegrate:
         )
         expected = np.sin(omega * t)
 
-        result = integrate(cosine_seismogram, clone=True)
+        result = integrate(cosine_seismogram, replace=True)
         npt.assert_allclose(result.data, expected, atol=1e-6)
 
     def test_round_trip_with_differentiate(
         self, sine_seismogram: MiniSeismogram
     ) -> None:
-        differentiated = differentiate(sine_seismogram, clone=True)
-        recovered = integrate(differentiated, clone=True)
+        differentiated = differentiate(sine_seismogram, replace=True)
+        recovered = integrate(differentiated, replace=True)
         npt.assert_allclose(recovered.data, sine_seismogram.data, atol=1e-6)
 
     def test_dc_bin_forced_to_zero_not_inf_or_nan(self, dt: float) -> None:
@@ -91,10 +91,10 @@ class TestIntegrate:
             delta=pd.Timedelta(seconds=dt),
             data=np.full(64, 3.0),
         )
-        result = integrate(seismogram, clone=True)
+        result = integrate(seismogram, replace=True)
         assert np.all(np.isfinite(result.data))
 
-    def test_clone_matches_in_place(self, sine_seismogram: MiniSeismogram) -> None:
+    def test_replace_matches_in_place(self, sine_seismogram: MiniSeismogram) -> None:
         assert_seismogram_modification(sine_seismogram, integrate)
 
     def test_empty_seismogram_raises(self, dt: float) -> None:

--- a/tests/tools/signal/test_delay.py
+++ b/tests/tools/signal/test_delay.py
@@ -79,7 +79,7 @@ def test_delay_with_seismogram(seismogram: Seismogram) -> None:
     rand_int = int(random.uniform(10, 100))
     seismogram1 = clone_to_mini(MiniSeismogram, seismogram)
     seismogram1.data = seismogram.data[1000:10000]
-    seismogram1 = detrend(seismogram1, clone=True)
+    seismogram1 = detrend(seismogram1, replace=True)
 
     seismogram2 = clone_to_mini(MiniSeismogram, seismogram1)
     seismogram2.delta = seismogram1.delta * 2
@@ -386,7 +386,7 @@ def test_multi_delay_with_seismogram(seismogram: Seismogram) -> None:
     """
     template = clone_to_mini(MiniSeismogram, seismogram)
     template.data = seismogram.data[1000:10000]
-    template = detrend(template, clone=True)
+    template = detrend(template, replace=True)
 
     shifts = [0, 15, -20]
     seismograms = []
@@ -555,7 +555,7 @@ def test_multi_multi_delay_with_seismogram(seismogram: Seismogram) -> None:
     """
     base = clone_to_mini(MiniSeismogram, seismogram)
     base.data = seismogram.data[1000:10000]
-    base = detrend(base, clone=True)
+    base = detrend(base, replace=True)
 
     shifts = [0, 10, -20]
     seismograms = []
@@ -794,7 +794,7 @@ def test_mccc_with_seismogram(seismogram: Seismogram) -> None:
     """
     base = clone_to_mini(MiniSeismogram, seismogram)
     base.data = seismogram.data[1000:10000]
-    base = detrend(base, clone=True)
+    base = detrend(base, replace=True)
 
     shifts = [0, 10, -20]
     seismograms = []

--- a/tests/tools/signal/test_response.py
+++ b/tests/tools/signal/test_response.py
@@ -86,7 +86,9 @@ class TestRoundTrip:
         # actually nonzero, letting the round trip stay exact.
         half_bin = freqs[1] / 2
         pre_filt = (half_bin / 2, half_bin, freqs[-1] - half_bin, freqs[-1])
-        recovered = remove_response(seismogram, response, pre_filt=pre_filt, clone=True)
+        recovered = remove_response(
+            seismogram, response, pre_filt=pre_filt, replace=True
+        )
 
         npt.assert_allclose(recovered.data, ground_motion, rtol=1e-6, atol=1e-6)
 
@@ -139,7 +141,7 @@ class TestRoundTrip:
             ),
             staged_response,
             pre_filt=pre_filt,
-            clone=True,
+            replace=True,
         )
         recovered_analog_only = remove_response(
             MiniSeismogram(
@@ -149,7 +151,7 @@ class TestRoundTrip:
             ),
             analog_only_response,
             pre_filt=pre_filt,
-            clone=True,
+            replace=True,
         )
 
         # Content in the FIR stage's stopband is attenuated by the stage's
@@ -305,7 +307,7 @@ class TestDigitalStageCorrection:
                 ],
             )
             return remove_response(
-                seismogram, response, pre_filt=pre_filt, clone=True
+                seismogram, response, pre_filt=pre_filt, replace=True
             ).data
 
         error_with_correction = np.sqrt(
@@ -357,10 +359,10 @@ class TestEmptyStages:
         pre_filt = (half_bin / 2, half_bin, freqs[-1] - half_bin, freqs[-1])
 
         result_plain = remove_response(
-            seismogram1, response, pre_filt=pre_filt, clone=True
+            seismogram1, response, pre_filt=pre_filt, replace=True
         )
         result_staged = remove_response(
-            seismogram2, staged_response, pre_filt=pre_filt, clone=True
+            seismogram2, staged_response, pre_filt=pre_filt, replace=True
         )
 
         npt.assert_array_equal(result_plain.data, result_staged.data)
@@ -389,7 +391,7 @@ class TestSensitivityOnly:
             reference_sensitivity=4.0,
             input_units="M/S",
         )
-        removed = remove_response(seismogram, response, clone=True)
+        removed = remove_response(seismogram, response, replace=True)
         npt.assert_array_equal(removed.data, ground_motion / 4.0)
 
     def test_ignores_digital_stages(self, dt: float, ground_motion: np.ndarray) -> None:
@@ -412,7 +414,7 @@ class TestSensitivityOnly:
                 )
             ],
         )
-        removed = remove_response(seismogram, response, clone=True)
+        removed = remove_response(seismogram, response, replace=True)
         npt.assert_array_equal(removed.data, ground_motion / 4.0)
 
     def test_missing_reference_sensitivity_raises(
@@ -454,7 +456,7 @@ class TestZeroHandling:
             seismogram,
             response,
             pre_filt=(1e-6, 1e-5, 0.8 * nyquist, 0.9 * nyquist),
-            clone=True,
+            replace=True,
         )
         assert np.all(np.isfinite(removed.data))
 
@@ -483,7 +485,7 @@ class TestZeroHandling:
             seismogram,
             response,
             pre_filt=(freqs[1] / 2, freqs[10], freqs[-10], freqs[-1] - freqs[1] / 2),
-            clone=True,
+            replace=True,
         )
         assert not np.all(np.isfinite(removed.data))
 
@@ -735,8 +737,10 @@ class TestSnapshot:
         )
 
 
-class TestClone:
-    def test_clone_matches_in_place(self, dt: float, ground_motion: np.ndarray) -> None:
+class TestReplace:
+    def test_replace_matches_in_place(
+        self, dt: float, ground_motion: np.ndarray
+    ) -> None:
         seismogram = MiniSeismogram(
             begin_time=pd.Timestamp("2010-01-01T00:00:00Z"),
             delta=pd.Timedelta(seconds=dt),
@@ -751,7 +755,7 @@ class TestClone:
         )
         assert_seismogram_modification(seismogram, remove_response, response)
 
-    def test_clone_matches_in_place_with_pre_filt(
+    def test_replace_matches_in_place_with_pre_filt(
         self, dt: float, ground_motion: np.ndarray
     ) -> None:
         nyquist = 0.5 / dt


### PR DESCRIPTION
Functions that modify seismograms now use `replace=True` to return a new object built via `copy.replace`, substituting only the affected fields (`data`, `begin_time`, `delta`) instead of deep-copying the whole object. `SacSeismogram` still raises `TypeError` since its data is a live view into an open SAC file. Updates propagate through docs, tests, and dependent tools (`project`, `signal`, `_geocsv`).

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--314.org.readthedocs.build/en/314/

<!-- readthedocs-preview pysmo end -->