### PR TITLE
feat(project): add cold-computable entry identity and get() addressing

### DIFF
--- a/src/pysmo/tools/project/__init__.py
+++ b/src/pysmo/tools/project/__init__.py
@@ -44,10 +44,7 @@ only detects drift on the live-network default rather than avoiding it.
 ## Basic example
 
 This example builds a small project around a single, real station/event
-pair: IU.ANMO recording the 2010-02-27 Maule, Chile M8.8 earthquake, the
-same reference event used throughout this project's test suite and in
-[`travel_times`][pysmo.tools.traveltime.travel_times]'s own `Examples:`
-block:
+pair: IU.ANMO recording the 2010-02-27 Maule, Chile M8.8 earthquake:
 
 ```python
 >>> import pandas as pd
@@ -271,12 +268,54 @@ is keyed by entry content, not list position:
 2
 >>>
 ```
+
+## Addressing entries
+
+[`entry.identity`][pysmo.tools.project.ProjectEntry.identity] is a stable
+string derived from the entry's natural key (normalised station code, event
+hypocentre and origin time, or explicit window), computed without any fetch.
+Persist it, and later pass it to
+[`project.get(identity)`][pysmo.tools.project.PysmoProject.get] to fetch and
+transform that one entry; `get` works on a project whose entries have never
+been fetched.
+
+[`project.resolution_context_digest`][pysmo.tools.project.PysmoProject.resolution_context_digest]
+is a single digest over the parameters that decide what a fetch returns
+(`phase`, `pre_pick`, `post_pick`, `travel_time_backend`,
+`seismogram_transform`). A consumer records it alongside the identities and
+checks it once per session to detect that the project definition has moved
+under it. Reassigning `fetch_seismogram` does not change the digest.
+
+The three are distinct:
+- `entry.identity` is computable before any fetch, and is the persistable
+  address.
+- `project.resolution_context_digest` catches a definition change before a
+  fetch is issued.
+- `entry.checksum` catches a change in the fetched bytes, and only exists
+  after a fetch.
 """
 
 from ..._utils import export_module_names
 from ._entry import ProjectEntry, build_entries
+from ._identity import (
+    UnknownEntryIdentity,
+    callable_identity,
+    entry_identity,
+    entry_identity_components,
+    resolution_context_digest,
+)
 from ._project import FetchContext, PysmoProject
 
-__all__ = ["FetchContext", "ProjectEntry", "PysmoProject", "build_entries"]
+__all__ = [
+    "FetchContext",
+    "ProjectEntry",
+    "PysmoProject",
+    "UnknownEntryIdentity",
+    "build_entries",
+    "callable_identity",
+    "entry_identity",
+    "entry_identity_components",
+    "resolution_context_digest",
+]
 
 export_module_names(globals(), __name__)

--- a/src/pysmo/tools/project/_entry.py
+++ b/src/pysmo/tools/project/_entry.py
@@ -1,12 +1,15 @@
 """The ProjectEntry class and the build_entries helper."""
 
 from collections.abc import Callable, Iterable
+from typing import Any
 
 import pandas as pd
 from attrs import converters, define, field, setters
 
 from pysmo import Event, Station
 from pysmo.lib.validators import convert_to_utc_timestamp
+
+from ._identity import entry_identity, entry_identity_components
 
 __all__ = ["ProjectEntry", "build_entries"]
 
@@ -83,6 +86,72 @@ class ProjectEntry[TStation: Station, TEvent: Event = Event]:
     fine; sharing them without being aware their checksum state is joint,
     not per-project, is the surprise to avoid.
     """
+
+    @property
+    def identity_components(self) -> dict[str, Any]:
+        """This entry's normalised natural key as a nested dict, before hashing.
+
+        Examples:
+            >>> import pandas as pd
+            >>> from pysmo import MiniEvent, MiniStation
+            >>> from pysmo.tools.project import ProjectEntry
+            >>> station = MiniStation(
+            ...     name="ANMO",
+            ...     network="IU",
+            ...     location="00",
+            ...     channel="BHZ",
+            ...     latitude=34.9459,
+            ...     longitude=-106.4571,
+            ... )
+            >>> event = MiniEvent(
+            ...     latitude=-36.122,
+            ...     longitude=-72.898,
+            ...     depth=22900.0,
+            ...     time=pd.Timestamp("2010-02-27T06:34:11.53Z"),
+            ... )
+            >>> entry = ProjectEntry(station=station, event=event)
+            >>> components = entry.identity_components
+            >>> components["schema"]
+            'v1'
+            >>> components["station"]["name"]
+            'ANMO'
+        """
+        return entry_identity_components(self)
+
+    @property
+    def identity(self) -> str:
+        """Stable identity string for this entry, computed without fetching.
+
+        Derived from the natural key: `'v1:'` and a sha256 hexdigest. Persist it
+        and pass it to
+        [`PysmoProject.get`][pysmo.tools.project.PysmoProject.get] to retrieve
+        the entry's seismogram later.
+
+        Examples:
+            >>> import pandas as pd
+            >>> from pysmo import MiniEvent, MiniStation
+            >>> from pysmo.tools.project import ProjectEntry
+            >>> station = MiniStation(
+            ...     name="ANMO",
+            ...     network="IU",
+            ...     location="00",
+            ...     channel="BHZ",
+            ...     latitude=34.9459,
+            ...     longitude=-106.4571,
+            ... )
+            >>> event = MiniEvent(
+            ...     latitude=-36.122,
+            ...     longitude=-72.898,
+            ...     depth=22900.0,
+            ...     time=pd.Timestamp("2010-02-27T06:34:11.53Z"),
+            ... )
+            >>> entry = ProjectEntry(station=station, event=event)
+            >>> entry.identity.startswith("v1:")
+            True
+            >>> len(entry.identity)
+            67
+        """
+        return entry_identity(self)
 
     def __attrs_post_init__(self) -> None:
         """Reject a half-specified, reversed, or (event-less) absent window."""

--- a/src/pysmo/tools/project/_identity.py
+++ b/src/pysmo/tools/project/_identity.py
@@ -1,0 +1,240 @@
+"""Precision constants, normalisation, canonical serialisation, and digests for project entry identity."""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import json
+import os
+from typing import TYPE_CHECKING, Any
+
+import attrs
+import pandas as pd
+
+from pysmo import Event, Station
+
+if TYPE_CHECKING:
+    from typing import Protocol
+
+    class _IdentityEntry(Protocol):
+        """The `ProjectEntry` attributes `entry_identity` reads."""
+
+        @property
+        def station(self) -> Station: ...
+        @property
+        def event(self) -> Event | None: ...
+        @property
+        def starttime(self) -> pd.Timestamp | None: ...
+        @property
+        def endtime(self) -> pd.Timestamp | None: ...
+
+    class _IdentityProject(Protocol):
+        """The `PysmoProject` attributes `resolution_context_digest` reads."""
+
+        @property
+        def phase(self) -> str: ...
+        @property
+        def pre_pick(self) -> pd.Timedelta: ...
+        @property
+        def post_pick(self) -> pd.Timedelta: ...
+        @property
+        def travel_time_backend(self) -> Any: ...
+        @property
+        def seismogram_transform(self) -> Any: ...
+
+
+_IDENTITY_SCHEMA = "v1"
+_LATLON_DP = 4  # ~11 m at the equator
+_DEPTH_QUANTUM_M = 100.0  # nearest 0.1 km
+
+
+class UnknownEntryIdentity(LookupError):
+    """Raised when an entry with the requested identity is not found in the project."""
+
+    def __init__(self, identity: str) -> None:
+        super().__init__(identity)
+        self.identity = identity
+
+
+def _no_negative_zero(x: float) -> float:
+    """Fold `-0.0` to `0.0` so rounded coordinates serialise identically."""
+    return x or 0.0
+
+
+def _normalise_station(station: Station) -> dict[str, str]:
+    """Station code fields, stripped; a blank or padded `location` becomes `''`."""
+    return {
+        "network": str(station.network).strip(),
+        "name": str(station.name).strip(),
+        "location": str(station.location).strip(),
+        "channel": str(station.channel).strip(),
+    }
+
+
+def _normalise_event(event: Event | None) -> dict[str, Any] | None:
+    """Event hypocentre and origin time; `None` when the entry has no event.
+
+    Latitude and longitude are rounded to `_LATLON_DP` decimal places and depth to
+    the nearest `_DEPTH_QUANTUM_M` metres; origin time is exact nanoseconds.
+    """
+    if event is None:
+        return None
+
+    lat = _no_negative_zero(round(float(event.latitude), _LATLON_DP))
+    lon = _no_negative_zero(round(float(event.longitude), _LATLON_DP))
+    depth_m = _no_negative_zero(
+        round(float(event.depth) / _DEPTH_QUANTUM_M) * _DEPTH_QUANTUM_M
+    )
+
+    return {
+        "latitude": lat,
+        "longitude": lon,
+        "depth_m": depth_m,
+        "time_ns": event.time.value,  # integer nanoseconds since Unix epoch UTC
+    }
+
+
+def _normalise_window(entry: _IdentityEntry) -> dict[str, Any] | None:
+    """The explicit window as integer-nanosecond bounds, or `None` if unset."""
+    if entry.starttime is None or entry.endtime is None:
+        return None
+    return {
+        "starttime_ns": entry.starttime.value,
+        "endtime_ns": entry.endtime.value,
+    }
+
+
+def _canonical(obj: Any) -> str:
+    """Serialise an object to a canonical, stable JSON string."""
+    return json.dumps(
+        obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def _prepare_json_value(val: Any) -> Any:
+    """Coerce a value to a JSON-serialisable form for canonical hashing.
+
+    `Timestamp` and `Timedelta` become integer nanoseconds, `PathLike` its string
+    form, and `-0.0` is folded to `0.0`. Anything not reducible to a JSON scalar,
+    list, or dict raises `TypeError`.
+    """
+    if isinstance(val, pd.Timestamp):
+        return val.value
+    if isinstance(val, pd.Timedelta):
+        return val.value
+    if isinstance(val, os.PathLike):
+        return os.fspath(val)
+    if isinstance(val, float):
+        return _no_negative_zero(val)
+    if isinstance(val, (str, int, bool, type(None))):
+        return val
+    if isinstance(val, (list, tuple)):
+        return [_prepare_json_value(item) for item in val]
+    if isinstance(val, dict):
+        return {str(k): _prepare_json_value(v) for k, v in val.items()}
+    raise TypeError(
+        f"Value {val!r} of type {type(val)} is not a supported scalar, Timestamp, "
+        + "Timedelta, or PathLike."
+    )
+
+
+def entry_identity_components(entry: _IdentityEntry) -> dict[str, Any]:
+    """The normalised natural key of an entry as a nested dict, before hashing.
+
+    Top-level keys are `schema`, `station`, `event`, and `window`; `event` and
+    `window` are `None` when absent.
+    """
+    return {
+        "schema": _IDENTITY_SCHEMA,
+        "station": _normalise_station(entry.station),
+        "event": _normalise_event(entry.event),
+        "window": _normalise_window(entry),
+    }
+
+
+def entry_identity(entry: _IdentityEntry) -> str:
+    """The entry's stable identity, computed from its natural key without I/O.
+
+    The string is `'v1:'` followed by a sha256 hexdigest.
+    """
+    payload = _canonical(entry_identity_components(entry))
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"{_IDENTITY_SCHEMA}:{digest}"
+
+
+def callable_identity(fn: Any) -> str:
+    """A stable, picklable identity string for a callable.
+
+    Supports:
+
+    - Top-level functions in importable modules.
+    - `functools.partial` wrapping a supported callable.
+    - `attrs` instances with picklable fields.
+
+    Raises `TypeError` for closures, lambdas, bound methods, classes, and other
+    objects.
+    """
+    if isinstance(fn, functools.partial):
+        func_id = callable_identity(fn.func)
+        args_prepared = [_prepare_json_value(arg) for arg in fn.args]
+        kw_prepared = {
+            k: _prepare_json_value(v) for k, v in (fn.keywords or {}).items()
+        }
+        payload = _canonical([args_prepared, kw_prepared])
+        return f"partial:{func_id}:{payload}"
+
+    if attrs.has(type(fn)):
+        raw_dict = attrs.asdict(fn, recurse=True)
+        payload = _canonical(_prepare_json_value(raw_dict))
+        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        return f"attrs:{type(fn).__module__}:{type(fn).__qualname__}:{digest}"
+
+    if callable(fn):
+        if isinstance(fn, type):
+            raise TypeError(
+                f"Callable {fn!r} must be a top-level function, functools.partial, "
+                + "or an attrs instance. Classes are not supported."
+            )
+        if hasattr(fn, "__self__"):
+            raise TypeError(
+                f"Callable {fn!r} is a bound method. Only top-level functions, "
+                + "functools.partial, or attrs instances are supported."
+            )
+        qualname = getattr(fn, "__qualname__", None)
+        module = getattr(fn, "__module__", None)
+        if qualname is not None:
+            if "<lambda>" in qualname or "<locals>" in qualname:
+                raise TypeError(
+                    f"Callable {fn!r} must be a top-level function, functools.partial, "
+                    + "or an attrs instance. Closures and lambdas are not supported."
+                )
+            if module is not None:
+                return f"func:{module}:{qualname}"
+
+    raise TypeError(
+        f"Callable {fn!r} of type {type(fn)} must be a top-level function, "
+        + "functools.partial, or an attrs instance."
+    )
+
+
+def resolution_context_digest(project: _IdentityProject) -> str:
+    """Digest over the project parameters that determine fetched content.
+
+    Covers `phase`, `pre_pick`, `post_pick`, `travel_time_backend`, and
+    `seismogram_transform`. Reassigning `fetch_seismogram` (e.g. to an offline
+    archive cache) leaves the digest unchanged.
+    """
+    payload = {
+        "schema": "rc1",
+        "phase": project.phase,
+        "pre_pick_ns": project.pre_pick.value,
+        "post_pick_ns": project.post_pick.value,
+        "travel_time_backend": callable_identity(project.travel_time_backend),
+        "seismogram_transform": callable_identity(project.seismogram_transform),
+    }
+    digest = hashlib.sha256(_canonical(payload).encode("utf-8")).hexdigest()
+    return f"rc1:{digest}"

--- a/src/pysmo/tools/project/_project.py
+++ b/src/pysmo/tools/project/_project.py
@@ -6,12 +6,12 @@ import hashlib
 import threading
 import warnings
 from collections.abc import Callable
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 import pandas as pd
 from attrs import Attribute, define, field, setters, validators
 
-from pysmo import Event, MiniSeismogram, Seismogram, Station
+from pysmo import Event, MiniSeismogram, Seismogram, Station, __version__
 from pysmo._utils import attrs_getstate, attrs_setstate
 from pysmo.classes import MSeed
 from pysmo.functions import clone_to_mini
@@ -21,6 +21,7 @@ from pysmo.tools.traveltime import TravelTimeBackend, builtin_backend
 from pysmo.typing import NonPositiveTimedelta, PositiveTimedelta
 
 from ._entry import ProjectEntry
+from ._identity import UnknownEntryIdentity, entry_identity, resolution_context_digest
 
 __all__ = ["FetchContext", "PysmoProject"]
 
@@ -161,6 +162,8 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
         still returns a result, it just isn't cached (the next call
         recomputes it with the current parameters).
     """
+
+    _FORMAT_VERSION: ClassVar[int] = 1
 
     entries: list[ProjectEntry[TStation, TEvent]] = field(
         factory=list, on_setattr=setters.pipe(setters.convert, _on_setattr_clear_cache)
@@ -334,10 +337,20 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
         """Drop the fetch cache and lock, neither of which can survive pickling."""
         state = attrs_getstate(self, {"_cache": {}, "_cache_generation": 0})
         del state["_lock"]
+        state["_format_version"] = self._FORMAT_VERSION
+        state["_pysmo_version"] = __version__
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         """Restore state without firing `on_setattr` hooks, then make a fresh lock."""
+        pickled_format = state.pop("_format_version", 0)
+        pickled_pysmo = state.pop("_pysmo_version", "unknown")
+        if pickled_format != self._FORMAT_VERSION:
+            raise ValueError(
+                f"This PysmoProject was pickled by pysmo {pickled_pysmo} in state "
+                + f"format v{pickled_format}; this pysmo ({__version__}) uses "
+                + f"v{self._FORMAT_VERSION}. Re-create the project."
+            )
         attrs_setstate(self, state)
         object.__setattr__(self, "_lock", threading.Lock())
 
@@ -516,6 +529,24 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
                 seen.append(entry.event)
         return seen
 
+    @property
+    def resolution_context_digest(self) -> str:
+        """Digest over the project parameters that determine fetched content.
+
+        Covers `phase`, `pre_pick`, `post_pick`, `travel_time_backend`, and
+        `seismogram_transform`. Reassigning `fetch_seismogram` (e.g. to an
+        offline archive cache) leaves the digest unchanged.
+
+        Examples:
+            >>> from pysmo.tools.project import PysmoProject
+            >>> project = PysmoProject()
+            >>> project.resolution_context_digest.startswith("rc1:")
+            True
+            >>> len(project.resolution_context_digest)
+            68
+        """
+        return resolution_context_digest(self)
+
     def events_for(self, station: TStation) -> list[TEvent | None]:
         """Events available for one station, in first-seen order.
 
@@ -570,6 +601,54 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
             raise ValueError(
                 "More than one entry matches this station/event combination."
             )
+        return self._fetch(matches[0], _stacklevel=_stacklevel)
+
+    def get(self, identity: str, *, _stacklevel: int = 3) -> TSeismogram:
+        """Fetch (or return from cache) the result for an entry by its identity.
+
+        Args:
+            identity: An [`entry.identity`][pysmo.tools.project.ProjectEntry.identity]
+                string. The entry need not have been fetched before.
+
+        Returns:
+            The transformed result for the matching entry.
+
+        Raises:
+            UnknownEntryIdentity: If no entry matches this identity.
+            ValueError: If more than one entry matches: an authoring mistake,
+                surfaced rather than silently resolved by picking one.
+
+        Examples:
+            >>> import pandas as pd
+            >>> from pysmo import MiniEvent, MiniSeismogram, MiniStation, Station
+            >>> from pysmo.tools.project import ProjectEntry, PysmoProject
+            >>> def fake_fetch(station: Station, t0: pd.Timestamp, t1: pd.Timestamp):
+            ...     return MiniSeismogram(
+            ...         begin_time=t0, delta=pd.Timedelta(seconds=1), data=[1.0, 2.0]
+            ...     )
+            >>> station = MiniStation(
+            ...     name="ANMO",
+            ...     network="IU",
+            ...     location="00",
+            ...     channel="BHZ",
+            ...     latitude=34.9459,
+            ...     longitude=-106.4571,
+            ... )
+            >>> entry = ProjectEntry(
+            ...     station=station,
+            ...     starttime=pd.Timestamp("2020-01-01T00:00:00Z"),
+            ...     endtime=pd.Timestamp("2020-01-01T00:10:00Z"),
+            ... )
+            >>> project = PysmoProject(entries=[entry], fetch_seismogram=fake_fetch)
+            >>> seis = project.get(entry.identity)
+            >>> len(seis.data)
+            2
+        """
+        matches = [e for e in self.entries if entry_identity(e) == identity]
+        if not matches:
+            raise UnknownEntryIdentity(identity)
+        if len(matches) > 1:
+            raise ValueError(f"More than one entry resolves to identity {identity!r}.")
         return self._fetch(matches[0], _stacklevel=_stacklevel)
 
     def seismograms_for(self, event: TEvent) -> list[TSeismogram]:

--- a/tests/tools/project/test_identity.py
+++ b/tests/tools/project/test_identity.py
@@ -1,0 +1,438 @@
+"""Tests for project entry identity and resolution context digest."""
+
+import functools
+import re
+from pathlib import Path
+from typing import Any
+
+import attrs
+import pandas as pd
+import pytest
+
+from pysmo import MiniEvent, MiniSeismogram, MiniStation, Seismogram, Station
+from pysmo.tools.project import (
+    FetchContext,
+    ProjectEntry,
+    PysmoProject,
+    callable_identity,
+    entry_identity,
+    resolution_context_digest,
+)
+from pysmo.tools.traveltime import travel_times
+
+
+def dummy_func(x: Any) -> Any:
+    return x
+
+
+def dummy_transform(seis: Seismogram, ctx: FetchContext[Any, Any]) -> Seismogram:
+    return seis
+
+
+def dummy_fetch(
+    station: Station, starttime: pd.Timestamp, endtime: pd.Timestamp
+) -> Seismogram:
+    return MiniSeismogram(begin_time=starttime, delta=pd.Timedelta(seconds=1), data=[])
+
+
+def another_dummy_fetch(
+    station: Station, starttime: pd.Timestamp, endtime: pd.Timestamp
+) -> Seismogram:
+    return MiniSeismogram(begin_time=starttime, delta=pd.Timedelta(seconds=1), data=[])
+
+
+type ProjectT = PysmoProject[MiniStation, MiniEvent, MiniSeismogram]
+
+
+@attrs.define
+class AttrsTransform:
+    corner: float
+    order: int = 4
+
+
+@attrs.define
+class AttrsFetcherWithPath:
+    db_path: Path
+    max_bytes: int | None = None
+
+    def __call__(
+        self, station: Station, starttime: pd.Timestamp, endtime: pd.Timestamp
+    ) -> Seismogram:
+        return MiniSeismogram(
+            begin_time=starttime, delta=pd.Timedelta(seconds=1), data=[]
+        )
+
+
+@attrs.define
+class DuckEvent:
+    latitude: float
+    longitude: float
+    depth: float
+    time: pd.Timestamp
+
+
+@attrs.define
+class DuckStation:
+    name: str
+    network: str
+    location: str
+    channel: str
+    latitude: float
+    longitude: float
+    elevation: float | None = None
+
+
+class TestEntryIdentity:
+    def test_identical_natural_keys_produce_equal_identity(self) -> None:
+        station1 = MiniStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+        station2 = MiniStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+        t = pd.Timestamp("2010-02-27T06:34:11.53Z")
+        event1 = MiniEvent(latitude=-36.122, longitude=-72.898, depth=22900.0, time=t)
+        event2 = MiniEvent(latitude=-36.122, longitude=-72.898, depth=22900.0, time=t)
+
+        entry1 = ProjectEntry(station=station1, event=event1)
+        entry2 = ProjectEntry(station=station2, event=event2)
+
+        assert entry1.identity == entry2.identity
+        assert entry1.identity_components == entry2.identity_components
+        assert entry_identity(entry1) == entry1.identity
+
+    def test_identity_format(self) -> None:
+        station = MiniStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+        event = MiniEvent(
+            latitude=-36.122,
+            longitude=-72.898,
+            depth=22900.0,
+            time=pd.Timestamp("2010-02-27T06:34:11.53Z"),
+        )
+        entry = ProjectEntry(station=station, event=event)
+        assert re.match(r"^v1:[0-9a-f]{64}$", entry.identity) is not None
+        assert entry.identity.startswith("v1:")
+        assert len(entry.identity) == 67
+
+    def test_lat_lon_jitter_tolerance(self) -> None:
+        station = MiniStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+        t = pd.Timestamp("2010-02-27T06:34:11.53Z")
+        base_event = MiniEvent(
+            latitude=-36.1220, longitude=-72.8980, depth=22900.0, time=t
+        )
+        # Nudge within precision (< 5e-5 deg): rounds to same 4 decimal places
+        nudged_event = MiniEvent(
+            latitude=-36.12204, longitude=-72.89803, depth=22900.0, time=t
+        )
+        # Nudge beyond precision: changes 4th decimal place
+        past_event = MiniEvent(
+            latitude=-36.1221, longitude=-72.8980, depth=22900.0, time=t
+        )
+
+        base_entry = ProjectEntry(station=station, event=base_event)
+        nudged_entry = ProjectEntry(station=station, event=nudged_event)
+        past_entry = ProjectEntry(station=station, event=past_event)
+
+        assert base_entry.identity == nudged_entry.identity
+        assert base_entry.identity != past_entry.identity
+
+    def test_depth_jitter_tolerance(self) -> None:
+        station = MiniStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+        t = pd.Timestamp("2010-02-27T06:34:11.53Z")
+        base_event = MiniEvent(
+            latitude=-36.1220, longitude=-72.8980, depth=10000.0, time=t
+        )
+        # Nudge within 50 m quantum: rounds to 10000.0
+        nudged_event = MiniEvent(
+            latitude=-36.1220, longitude=-72.8980, depth=10040.0, time=t
+        )
+        # Nudge past quantum: rounds to 10100.0
+        past_event = MiniEvent(
+            latitude=-36.1220, longitude=-72.8980, depth=10060.0, time=t
+        )
+
+        base_entry = ProjectEntry(station=station, event=base_event)
+        nudged_entry = ProjectEntry(station=station, event=nudged_event)
+        past_entry = ProjectEntry(station=station, event=past_event)
+
+        assert base_entry.identity == nudged_entry.identity
+        assert base_entry.identity != past_entry.identity
+
+    def test_origin_time_nudged_by_one_nanosecond_changes_identity(self) -> None:
+        station = MiniStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+        t0 = pd.Timestamp("2010-02-27T06:34:11.530000000Z")
+        t1 = pd.Timestamp("2010-02-27T06:34:11.530000001Z")
+        event0 = MiniEvent(
+            latitude=-36.1220, longitude=-72.8980, depth=22900.0, time=t0
+        )
+        event1 = MiniEvent(
+            latitude=-36.1220, longitude=-72.8980, depth=22900.0, time=t1
+        )
+
+        entry0 = ProjectEntry(station=station, event=event0)
+        entry1 = ProjectEntry(station=station, event=event1)
+
+        assert entry0.identity != entry1.identity
+
+    def test_station_location_canonicalisation(self) -> None:
+        event = MiniEvent(
+            latitude=-36.1220,
+            longitude=-72.8980,
+            depth=22900.0,
+            time=pd.Timestamp("2010-02-27T06:34:11.53Z"),
+        )
+        s_blank = DuckStation(
+            name="ANMO",
+            network="IU",
+            location="",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+        s_padded = DuckStation(
+            name="ANMO",
+            network="IU",
+            location="  ",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+        s_spaced_zero = DuckStation(
+            name="ANMO",
+            network="IU",
+            location=" 0 ",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+        s_zero_zero = DuckStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+
+        e_blank = ProjectEntry(station=s_blank, event=event)
+        e_padded = ProjectEntry(station=s_padded, event=event)
+        e_spaced_zero = ProjectEntry(station=s_spaced_zero, event=event)
+        e_zero_zero = ProjectEntry(station=s_zero_zero, event=event)
+
+        assert e_blank.identity == e_padded.identity
+        assert e_blank.identity_components["station"]["location"] == ""
+        assert e_spaced_zero.identity_components["station"]["location"] == "0"
+        assert e_zero_zero.identity != e_blank.identity
+        assert e_zero_zero.identity != e_spaced_zero.identity
+
+    def test_eventless_entry_with_explicit_window(self) -> None:
+        station = MiniStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+        t0 = pd.Timestamp("2020-01-01T00:00:00Z")
+        t1 = pd.Timestamp("2020-01-01T01:00:00Z")
+        t2 = pd.Timestamp("2020-01-01T02:00:00Z")
+
+        entry1 = ProjectEntry(station=station, starttime=t0, endtime=t1)
+        entry2 = ProjectEntry(station=station, starttime=t0, endtime=t2)
+
+        assert entry1.identity_components["event"] is None
+        assert entry1.identity_components["window"] == {
+            "starttime_ns": t0.value,
+            "endtime_ns": t1.value,
+        }
+        assert entry1.identity != entry2.identity
+
+    def test_integer_coordinates_match_float_equivalents(self) -> None:
+        station = MiniStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="BHZ",
+            latitude=34.9459,
+            longitude=-106.4571,
+        )
+        t = pd.Timestamp("2020-01-01T00:00:00Z")
+        float_event = MiniEvent(latitude=12.0, longitude=34.0, depth=10000.0, time=t)
+        # A duck-typed Event exposing integer coordinates.
+        int_event = DuckEvent(latitude=12, longitude=34, depth=10000, time=t)
+
+        entry_float = ProjectEntry(station=station, event=float_event)
+        entry_int = ProjectEntry(station=station, event=int_event)
+
+        assert entry_float.identity == entry_int.identity
+
+    def test_negative_zero_normalisation(self) -> None:
+        station = MiniStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="BHZ",
+            latitude=0.0,
+            longitude=0.0,
+        )
+        t = pd.Timestamp("2020-01-01T00:00:00Z")
+        event_neg = MiniEvent(latitude=-0.0, longitude=-0.0, depth=-0.0, time=t)
+        event_pos = MiniEvent(latitude=0.0, longitude=0.0, depth=0.0, time=t)
+
+        entry_neg = ProjectEntry(station=station, event=event_neg)
+        entry_pos = ProjectEntry(station=station, event=event_pos)
+
+        assert entry_neg.identity == entry_pos.identity
+        assert entry_neg.identity_components["event"] == {
+            "latitude": 0.0,
+            "longitude": 0.0,
+            "depth_m": 0.0,
+            "time_ns": t.value,
+        }
+
+
+class TestCallableIdentity:
+    def test_top_level_function(self) -> None:
+        cid = callable_identity(dummy_func)
+        assert cid == f"func:{dummy_func.__module__}:{dummy_func.__qualname__}"
+
+    def test_functools_partial(self) -> None:
+        p1 = functools.partial(travel_times, model="ak135")
+        p2 = functools.partial(travel_times, model="ak135")
+        p3 = functools.partial(travel_times, model="iasp91")
+
+        cid1 = callable_identity(p1)
+        cid2 = callable_identity(p2)
+        cid3 = callable_identity(p3)
+
+        assert cid1 == cid2
+        assert cid1 != cid3
+        assert cid1.startswith("partial:func:")
+        assert "ak135" in cid1
+
+    def test_attrs_instance(self) -> None:
+        inst1 = AttrsTransform(corner=1.0, order=4)
+        inst2 = AttrsTransform(corner=1.0, order=4)
+        inst3 = AttrsTransform(corner=2.0, order=4)
+
+        cid1 = callable_identity(inst1)
+        cid2 = callable_identity(inst2)
+        cid3 = callable_identity(inst3)
+
+        assert cid1 == cid2
+        assert cid1 != cid3
+        assert cid1.startswith("attrs:")
+
+    def test_attrs_instance_with_path_field(self) -> None:
+        inst1 = AttrsFetcherWithPath(db_path=Path("/data/archive.sqlite"))
+        inst2 = AttrsFetcherWithPath(db_path=Path("/data/archive.sqlite"))
+        inst3 = AttrsFetcherWithPath(db_path=Path("/data/other.sqlite"))
+
+        assert callable_identity(inst1) == callable_identity(inst2)
+        assert callable_identity(inst1) != callable_identity(inst3)
+        assert callable_identity(inst1).startswith("attrs:")
+
+    def test_unsupported_callables_raise_type_error(self) -> None:
+        # Lambda
+        with pytest.raises(TypeError, match="Closures and lambdas are not supported"):
+            callable_identity(lambda x: x)
+
+        # Local function / closure
+        def local_fn() -> None:
+            pass
+
+        with pytest.raises(TypeError, match="Closures and lambdas are not supported"):
+            callable_identity(local_fn)
+
+        # Class itself
+        with pytest.raises(TypeError, match="Classes are not supported"):
+            callable_identity(AttrsTransform)
+
+        # Bound method
+        class Plain:
+            def method(self) -> None:
+                pass
+
+        obj = Plain()
+        with pytest.raises(TypeError, match="bound method"):
+            callable_identity(obj.method)
+
+        # Non-callable non-attrs
+        with pytest.raises(TypeError, match="must be a top-level function"):
+            callable_identity("not-a-callable")
+
+
+class TestResolutionContextDigest:
+    def test_format_and_stability(self) -> None:
+        project: ProjectT = PysmoProject()
+        digest = resolution_context_digest(project)
+        assert re.match(r"^rc1:[0-9a-f]{64}$", digest) is not None
+        assert digest.startswith("rc1:")
+        assert len(digest) == 68
+
+    def test_digest_changes_on_relevant_parameters(self) -> None:
+        p1: ProjectT = PysmoProject(phase="P")
+        d1 = resolution_context_digest(p1)
+
+        p2: ProjectT = PysmoProject(phase="S")
+        assert resolution_context_digest(p2) != d1
+
+        p3: ProjectT = PysmoProject(pre_pick=pd.Timedelta(minutes=-3))
+        assert resolution_context_digest(p3) != d1
+
+        p4: ProjectT = PysmoProject(post_pick=pd.Timedelta(minutes=10))
+        assert resolution_context_digest(p4) != d1
+
+        p5: ProjectT = PysmoProject(
+            travel_time_backend=functools.partial(travel_times, model="ak135")
+        )
+        assert resolution_context_digest(p5) != d1
+
+        p6: PysmoProject[MiniStation, MiniEvent, Seismogram] = PysmoProject(
+            seismogram_transform=dummy_transform
+        )
+        assert resolution_context_digest(p6) != d1
+
+    def test_digest_excludes_fetch_seismogram(self) -> None:
+        p1: ProjectT = PysmoProject(fetch_seismogram=dummy_fetch)
+        p2: ProjectT = PysmoProject(fetch_seismogram=another_dummy_fetch)
+        assert resolution_context_digest(p1) == resolution_context_digest(p2)

--- a/tests/tools/project/test_project.py
+++ b/tests/tools/project/test_project.py
@@ -17,6 +17,7 @@ from pysmo.tools.project import (
     FetchContext,
     ProjectEntry,
     PysmoProject,
+    UnknownEntryIdentity,
     build_entries,
 )
 
@@ -494,6 +495,71 @@ class TestSeismogramsFor:
         assert project.seismograms_for(event_other) == []
 
 
+class TestGet:
+    def test_get_happy_path(
+        self, project: ProjectT, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        entry = project.entries[0]
+        result = project.get(entry.identity)
+        assert len(FETCH_CALLS) == 1
+        assert FETCH_CALLS[0][0] == "ANMO"
+        assert list(result.data) == [1.0, 2.0, 3.0]
+
+    def test_get_cold_miss_and_subsequent_cached(
+        self,
+        station_anmo: MiniStation,
+        station_cacb: MiniStation,
+        event_maule: MiniEvent,
+    ) -> None:
+        entry1 = ProjectEntry(station=station_anmo, event=event_maule)
+        entry2 = ProjectEntry(station=station_cacb, event=event_maule)
+        project = PysmoProject(
+            entries=[entry1, entry2],
+            seismogram_transform=identity_transform,
+            fetch_seismogram=fake_fetch_seismogram,
+            travel_time_backend=fake_travel_time_backend,
+        )
+
+        # Cold project, fetch only entry1 by identity
+        r1 = project.get(entry1.identity)
+        assert len(FETCH_CALLS) == 1
+        assert FETCH_CALLS[0][0] == "ANMO"
+
+        # Subsequent call uses cache
+        r1_again = project.get(entry1.identity)
+        assert len(FETCH_CALLS) == 1
+        assert r1 == r1_again
+
+        # Fetching entry2 fetches only entry2
+        _ = project.get(entry2.identity)
+        assert len(FETCH_CALLS) == 2
+        assert FETCH_CALLS[1][0] == "CACB"
+
+    def test_get_unknown_identity_raises(self, project: ProjectT) -> None:
+        fake_id = "v1:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        with pytest.raises(UnknownEntryIdentity) as exc_info:
+            project.get(fake_id)
+        assert exc_info.value.identity == fake_id
+        assert isinstance(exc_info.value, LookupError)
+
+    def test_get_multiple_matches_raises_value_error(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        entry1 = ProjectEntry(station=station_anmo, event=event_maule)
+        entry2 = ProjectEntry(station=station_anmo, event=event_maule)
+        project = PysmoProject(
+            entries=[entry1, entry2],
+            seismogram_transform=identity_transform,
+            fetch_seismogram=fake_fetch_seismogram,
+            travel_time_backend=fake_travel_time_backend,
+        )
+        assert entry1.identity == entry2.identity
+        with pytest.raises(
+            ValueError, match="More than one entry resolves to identity"
+        ):
+            project.get(entry1.identity)
+
+
 class TestPickling:
     def test_cache_empty_after_round_trip_but_entries_survive(
         self, station_anmo: MiniStation, event_maule: MiniEvent
@@ -537,6 +603,36 @@ class TestPickling:
         used.seismogram(station_anmo, event_maule)  # populates used._cache only
 
         assert used == unused
+
+    def test_format_version_mismatch_raises_on_unpickle(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        project = PysmoProject(
+            entries=[ProjectEntry(station=station_anmo, event=event_maule)],
+            seismogram_transform=identity_transform,
+            fetch_seismogram=fake_fetch_seismogram,
+            travel_time_backend=fake_travel_time_backend,
+        )
+        state = project.__getstate__()
+        state["_format_version"] = 999
+        with pytest.raises(
+            ValueError, match=r"state format v999; this pysmo .* uses v1"
+        ):
+            project.__setstate__(state)
+
+    def test_missing_format_version_defaults_to_zero_and_raises(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        project = PysmoProject(
+            entries=[ProjectEntry(station=station_anmo, event=event_maule)],
+            seismogram_transform=identity_transform,
+            fetch_seismogram=fake_fetch_seismogram,
+            travel_time_backend=fake_travel_time_backend,
+        )
+        state = project.__getstate__()
+        del state["_format_version"]
+        with pytest.raises(ValueError, match=r"state format v0; this pysmo .* uses v1"):
+            project.__setstate__(state)
 
 
 class TestThreadSafety:
@@ -747,6 +843,51 @@ def test_default_fetch_seismogram_live(
     )
     seismogram = project.seismogram(station_anmo, event_maule)
     assert len(seismogram.data) > 0
+
+
+class TestProjectResolutionContextDigest:
+    def test_digest_stable_across_fetch_seismogram_swap(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        project = PysmoProject(
+            entries=[ProjectEntry(station=station_anmo, event=event_maule)],
+            seismogram_transform=identity_transform,
+            fetch_seismogram=fake_fetch_seismogram,
+            travel_time_backend=fake_travel_time_backend,
+        )
+        d1 = project.resolution_context_digest
+
+        project.fetch_seismogram = other_fake_fetch_seismogram
+        assert project.resolution_context_digest == d1
+
+    def test_digest_changes_on_phase_swap(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        project = PysmoProject(
+            entries=[ProjectEntry(station=station_anmo, event=event_maule)],
+            seismogram_transform=identity_transform,
+            fetch_seismogram=fake_fetch_seismogram,
+            travel_time_backend=fake_travel_time_backend,
+            phase="P",
+        )
+        d1 = project.resolution_context_digest
+
+        project.phase = "S"
+        assert project.resolution_context_digest != d1
+
+    def test_digest_changes_on_transform_swap(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        project = PysmoProject(
+            entries=[ProjectEntry(station=station_anmo, event=event_maule)],
+            seismogram_transform=identity_transform,
+            fetch_seismogram=fake_fetch_seismogram,
+            travel_time_backend=fake_travel_time_backend,
+        )
+        d1 = project.resolution_context_digest
+
+        project.seismogram_transform = other_identity_transform
+        assert project.resolution_context_digest != d1
 
 
 class TestBuildEntries:


### PR DESCRIPTION
Every ProjectEntry now has a stable `identity` string derived from its natural key with no I/O, and `PysmoProject.get(identity)` resolves it, fetching and transforming that single entry on an otherwise-cold project. Adds `resolution_context_digest` (a per-session check that the fetch-window parameters have not moved), `callable_identity`, and a hand-bumped `_FORMAT_VERSION` guarding the pickle state.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--315.org.readthedocs.build/en/315/

<!-- readthedocs-preview pysmo end -->