### PR TITLE
feat(project)!: make the fetch window a pluggable seam

### DIFF
--- a/src/pysmo/_utils.py
+++ b/src/pysmo/_utils.py
@@ -27,8 +27,14 @@ def export_module_names(globals_dict: dict[str, Any], module_name: str) -> None:
 
     for name in all_names:
         obj = globals_dict.get(name)
-        if obj is not None and hasattr(obj, "__module__"):
+        if obj is None or not hasattr(obj, "__module__"):
+            continue
+        try:
             obj.__module__ = module_name
+        except AttributeError:
+            # `TypeAliasType` (a `type X = ...` alias) has a read-only
+            # `__module__`; griffe resolves it via `__all__` re-export anyway.
+            pass
 
 
 def attrs_getstate(

--- a/src/pysmo/tools/project/__init__.py
+++ b/src/pysmo/tools/project/__init__.py
@@ -4,9 +4,9 @@
 A [`PysmoProject`][pysmo.tools.project.PysmoProject] holds a list of
 [`ProjectEntry`][pysmo.tools.project.ProjectEntry] objects (a station, an
 optional event, and an optional explicit window) plus a `seismogram_transform`
-callable applied to each freshly downloaded
-[`Seismogram`][pysmo.Seismogram]. It defaults to returning the raw trace as
-a [`MiniSeismogram`][pysmo.MiniSeismogram]; a custom transform is the place
+callable applied to each freshly downloaded [`Seismogram`][pysmo.Seismogram].
+It defaults to returning the raw trace as a
+[`MiniSeismogram`][pysmo.MiniSeismogram]; a custom transform is the place
 for whatever data preparation a downstream tool needs (removing the
 instrument response, detrending, resampling), as well as converting the
 result into the target type that tool expects (e.g.
@@ -15,14 +15,17 @@ result into the target type that tool expects (e.g.
 of the object; nothing is ever written to disk by `PysmoProject` itself.
 
 The `PysmoProject` instance is the reproducible, shareable artefact: it is
-pickled, not serialised to a bespoke config format, so `seismogram_transform`
-and
-`fetch_seismogram` must be real top-level functions in an importable module
-rather than lambdas or closures (pickle serialises functions by reference,
-not by value). A callable `attrs` class with only picklable fields (see the
-example below) is the alternative once the transform needs its own
-configuration (e.g. filter corner frequencies): it pickles by value, so it
-has no such restriction.
+pickled, not serialised to a bespoke config format, so its three pluggable
+callables (`window`, `fetch_seismogram`, `seismogram_transform`) must be real
+top-level functions in an importable module rather than lambdas or closures
+(pickle serialises functions by reference, not by value). A callable that
+needs its own configuration (e.g. filter corner frequencies) should be a
+callable [`attrs`][] class with only picklable fields (see the example below):
+it pickles by value, and its declared fields are what let
+`resolution_context_digest` fingerprint `window` and `seismogram_transform`.
+A plain callable class pickles too, but the digest cannot read one.
+[`PhaseWindow`][pysmo.tools.project.PhaseWindow], the default `window`, is
+one such class.
 
 Build `entries` with
 [`build_entries`][pysmo.tools.project.build_entries] from already-narrowed
@@ -70,8 +73,8 @@ pair: IU.ANMO recording the 2010-02-27 Maule, Chile M8.8 earthquake:
 This `seismogram_transform` removes the instrument response, the data
 preparation `ICCS` itself assumes has already happened (per its own
 [`bandpass_apply`][pysmo.tools.iccs.ICCS.bandpass_apply] docstring), then
-converts the result into a `MiniIccsSeismogram`, using the predicted
-arrival on `context` as the initial pick (see
+converts the result into a `MiniIccsSeismogram`, using `context.reference`
+(the predicted arrival) as the initial pick (see
 [`FetchContext`][pysmo.tools.project.FetchContext]). It's a callable
 `attrs` class rather than a plain function specifically so `pre_filt` is
 configurable per instance:
@@ -88,7 +91,7 @@ configurable per instance:
 ...             station=context.entry.station, time=context.starttime
 ...         ).response
 ...         corrected = clone_to_mini(
-...             MiniIccsSeismogram, seismogram, update={"t0": context.predicted}
+...             MiniIccsSeismogram, seismogram, update={"t0": context.reference}
 ...         )
 ...         remove_response(corrected, response, pre_filt=self.pre_filt)
 ...         return corrected
@@ -132,25 +135,51 @@ True
 ```
 <!-- skip: end -->
 
-## A different travel-time model
+## The fetch window
 
-When an entry carries an event but no explicit window, the window is
-placed around a predicted phase arrival, by default
-[`travel_times`][pysmo.tools.traveltime.travel_times] on its own default
-model. `travel_time_backend` swaps that for any callable of the same
-shape ([`TravelTimeBackend`][pysmo.tools.traveltime.TravelTimeBackend]).
-Here it is the same solver on the ak135 model, via
-[`functools.partial`][]:
+An entry's window comes from one of two places.
+
+The first is the entry itself. If it sets `starttime` and `endtime`, that
+window is used as-is and `window` is never called. A `ProjectEntry` with no
+event is rejected unless it sets an explicit window, so every event-less
+entry takes this path. An entry that carries an event can also set an
+explicit window, to override the event-derived one.
+
+```python
+>>> pre_maule_noise = PysmoProject(
+...     entries=[
+...         ProjectEntry(
+...             station=station_anmo,
+...             starttime="2010-02-27T05:00:00Z",
+...             endtime="2010-02-27T06:00:00Z",
+...         )
+...     ],
+... )
+>>> pre_maule_noise.events
+[]
+>>> pre_maule_noise.events_for(station_anmo)
+[None]
+>>>
+```
+
+The second is the `window` resolver. It runs when an entry has an event but
+no explicit window. The default resolver is
+[`PhaseWindow`][pysmo.tools.project.PhaseWindow]. It returns a span around
+the predicted phase arrival. Its `phase`, `pre_pick`, `post_pick`, and
+`travel_time_backend` fields live on the `PhaseWindow`, not on
+`PysmoProject`. The example below sets `travel_time_backend` to the
+built-in solver on the ak135 model:
 
 ```python
 >>> from functools import partial
+>>> from pysmo.tools.project import PhaseWindow
 >>> from pysmo.tools.traveltime import travel_times
 >>>
 >>> project_ak135 = PysmoProject(
 ...     entries=[ProjectEntry(station=station_anmo, event=event_maule)],
-...     travel_time_backend=partial(travel_times, model="ak135"),
+...     window=PhaseWindow(travel_time_backend=partial(travel_times, model="ak135")),
 ... )
->>> arrivals = project_ak135.travel_time_backend(
+>>> arrivals = project_ak135.window.travel_time_backend(
 ...     depth=event_maule.depth, distance=60.0, phases=["P"]
 ... )
 >>> round(arrivals["P"].total_seconds(), 1)
@@ -158,8 +187,8 @@ Here it is the same solver on the ak135 model, via
 >>>
 ```
 
-The same hook takes a solver for a phase the built-in one does not
-cover, or arrival times from an external catalogue.
+Any [`WindowResolver`][pysmo.tools.project.WindowResolver] can take the
+place of `PhaseWindow`.
 
 ## Caching downloads
 
@@ -281,10 +310,10 @@ been fetched.
 
 [`project.resolution_context_digest`][pysmo.tools.project.PysmoProject.resolution_context_digest]
 is a single digest over the parameters that decide what a fetch returns
-(`phase`, `pre_pick`, `post_pick`, `travel_time_backend`,
-`seismogram_transform`). A consumer records it alongside the identities and
-checks it once per session to detect that the project definition has moved
-under it. Reassigning `fetch_seismogram` does not change the digest.
+(`window` and `seismogram_transform`). A consumer records it alongside the
+identities and checks it once per session to detect that the project
+definition has moved under it. Reassigning `fetch_seismogram` does not
+change the digest.
 
 The three are distinct:
 - `entry.identity` is computable before any fetch, and is the persistable
@@ -304,13 +333,26 @@ from ._identity import (
     entry_identity_components,
     resolution_context_digest,
 )
-from ._project import FetchContext, PysmoProject
+from ._phasewindow import PhaseWindow
+from ._project import PysmoProject
+from ._types import (
+    FetchContext,
+    SeismogramFetcher,
+    SeismogramTransform,
+    WindowResolver,
+    WindowResult,
+)
 
 __all__ = [
     "FetchContext",
+    "PhaseWindow",
     "ProjectEntry",
     "PysmoProject",
+    "SeismogramFetcher",
+    "SeismogramTransform",
     "UnknownEntryIdentity",
+    "WindowResolver",
+    "WindowResult",
     "build_entries",
     "callable_identity",
     "entry_identity",

--- a/src/pysmo/tools/project/_identity.py
+++ b/src/pysmo/tools/project/_identity.py
@@ -32,13 +32,7 @@ if TYPE_CHECKING:
         """The `PysmoProject` attributes `resolution_context_digest` reads."""
 
         @property
-        def phase(self) -> str: ...
-        @property
-        def pre_pick(self) -> pd.Timedelta: ...
-        @property
-        def post_pick(self) -> pd.Timedelta: ...
-        @property
-        def travel_time_backend(self) -> Any: ...
+        def window(self) -> Any: ...
         @property
         def seismogram_transform(self) -> Any: ...
 
@@ -188,8 +182,19 @@ def callable_identity(fn: Any) -> str:
         return f"partial:{func_id}:{payload}"
 
     if attrs.has(type(fn)):
-        raw_dict = attrs.asdict(fn, recurse=True)
-        payload = _canonical(_prepare_json_value(raw_dict))
+        fields_payload: dict[str, Any] = {}
+        for attribute in attrs.fields(type(fn)):
+            value = getattr(fn, attribute.name)
+            if attrs.has(type(value)) or (
+                callable(value) and not isinstance(value, (str, bytes))
+            ):
+                # A nested callable field (e.g. a travel-time backend held as
+                # a `functools.partial`) that `_prepare_json_value` cannot
+                # reduce: digest it recursively instead.
+                fields_payload[attribute.name] = callable_identity(value)
+            else:
+                fields_payload[attribute.name] = _prepare_json_value(value)
+        payload = _canonical(fields_payload)
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         return f"attrs:{type(fn).__module__}:{type(fn).__qualname__}:{digest}"
 
@@ -224,17 +229,13 @@ def callable_identity(fn: Any) -> str:
 def resolution_context_digest(project: _IdentityProject) -> str:
     """Digest over the project parameters that determine fetched content.
 
-    Covers `phase`, `pre_pick`, `post_pick`, `travel_time_backend`, and
-    `seismogram_transform`. Reassigning `fetch_seismogram` (e.g. to an offline
-    archive cache) leaves the digest unchanged.
+    Covers `window` and `seismogram_transform`. Reassigning `fetch_seismogram`
+    (e.g. to an offline archive cache) leaves the digest unchanged.
     """
     payload = {
-        "schema": "rc1",
-        "phase": project.phase,
-        "pre_pick_ns": project.pre_pick.value,
-        "post_pick_ns": project.post_pick.value,
-        "travel_time_backend": callable_identity(project.travel_time_backend),
+        "schema": "rc2",
+        "window": callable_identity(project.window),
         "seismogram_transform": callable_identity(project.seismogram_transform),
     }
     digest = hashlib.sha256(_canonical(payload).encode("utf-8")).hexdigest()
-    return f"rc1:{digest}"
+    return f"rc2:{digest}"

--- a/src/pysmo/tools/project/_phasewindow.py
+++ b/src/pysmo/tools/project/_phasewindow.py
@@ -1,0 +1,102 @@
+"""The PhaseWindow resolver: a window placed around a predicted phase arrival."""
+
+from __future__ import annotations
+
+import pandas as pd
+from attrs import define, field, validators
+
+from pysmo import Event, Station
+from pysmo.lib.validators import convert_to_timedelta
+from pysmo.tools.azdist import haversine
+from pysmo.tools.traveltime import TravelTimeBackend, builtin_backend
+from pysmo.typing import NonPositiveTimedelta, PositiveTimedelta
+
+from ._entry import ProjectEntry
+from ._types import WindowResult
+
+__all__ = ["PhaseWindow"]
+
+
+@define(kw_only=True, frozen=True)
+class PhaseWindow:
+    """Resolve a fetch window from an entry's event and a predicted phase arrival.
+
+    The default [`WindowResolver`][pysmo.tools.project.WindowResolver] for
+    [`PysmoProject`][pysmo.tools.project.PysmoProject]: predicts the `phase`
+    arrival for the station/event geometry with `travel_time_backend`, then
+    returns the window `[arrival + pre_pick, arrival + post_pick]`.
+
+    Frozen and picklable by value (given a picklable `travel_time_backend`),
+    so it travels with a pickled `PysmoProject`.
+    """
+
+    phase: str = field(default="P")
+    """Seismic phase the window is placed around.
+
+    With the default `travel_time_backend` this must be one of the phases in
+    [`Phase`][pysmo.tools.traveltime.Phase]; any other name raises when a
+    window is resolved. A custom backend may accept a wider set.
+    """
+
+    pre_pick: NonPositiveTimedelta = field(
+        default=pd.Timedelta(minutes=-2),
+        converter=convert_to_timedelta,
+        validator=[
+            validators.instance_of(pd.Timedelta),
+            validators.le(pd.Timedelta(0)),
+        ],
+    )
+    """Offset from the predicted arrival to the window start; zero or negative."""
+
+    post_pick: PositiveTimedelta = field(
+        default=pd.Timedelta(minutes=8),
+        converter=convert_to_timedelta,
+        validator=[
+            validators.instance_of(pd.Timedelta),
+            validators.gt(pd.Timedelta(0)),
+        ],
+    )
+    """Offset from the predicted arrival to the window end. Must be positive."""
+
+    travel_time_backend: TravelTimeBackend = field(default=builtin_backend)
+    """Predicts the phase arrival the window is built around.
+
+    Defaults to pysmo's built-in solver,
+    [`travel_times`][pysmo.tools.traveltime.travel_times]. Replace it with
+    any callable of the same shape
+    ([`TravelTimeBackend`][pysmo.tools.traveltime.TravelTimeBackend]) for
+    another velocity model, a phase the built-in solver does not cover, or
+    arrival times from an external source. Must be picklable: a top-level
+    function, a [`functools.partial`][] of one, or an attrs instance with
+    only picklable fields; not a lambda or closure.
+    """
+
+    def __call__[TS: Station, TE: Event](
+        self, entry: ProjectEntry[TS, TE]
+    ) -> WindowResult:
+        """Resolve the window for `entry`.
+
+        Raises:
+            ValueError: If `entry` has no event, or no `phase` arrival is
+                predicted for its station/event geometry.
+        """
+        if entry.event is None:
+            raise ValueError(
+                "PhaseWindow needs an entry with an event to derive a window."
+            )
+        distance = haversine(entry.event, entry.station)
+        arrivals = self.travel_time_backend(
+            depth=entry.event.depth, distance=distance, phases=[self.phase]
+        )
+        if self.phase not in arrivals:
+            raise ValueError(
+                f"No {self.phase!r} arrival predicted for "
+                + f"{entry.station.network}.{entry.station.name} at this "
+                + "distance/depth."
+            )
+        reference = entry.event.time + arrivals[self.phase]
+        return WindowResult(
+            starttime=reference + self.pre_pick,
+            endtime=reference + self.post_pick,
+            reference=reference,
+        )

--- a/src/pysmo/tools/project/_project.py
+++ b/src/pysmo/tools/project/_project.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import threading
 import warnings
-from collections.abc import Callable
 from typing import Any, ClassVar, Literal
 
 import pandas as pd
@@ -15,13 +14,17 @@ from pysmo import Event, MiniSeismogram, Seismogram, Station, __version__
 from pysmo._utils import attrs_getstate, attrs_setstate
 from pysmo.classes import MSeed
 from pysmo.functions import clone_to_mini
-from pysmo.lib.validators import convert_to_timedelta
-from pysmo.tools.azdist import haversine
-from pysmo.tools.traveltime import TravelTimeBackend, builtin_backend
-from pysmo.typing import NonPositiveTimedelta, PositiveTimedelta
 
 from ._entry import ProjectEntry
 from ._identity import UnknownEntryIdentity, entry_identity, resolution_context_digest
+from ._phasewindow import PhaseWindow
+from ._types import (
+    FetchContext,
+    SeismogramFetcher,
+    SeismogramTransform,
+    WindowResolver,
+    WindowResult,
+)
 
 __all__ = ["FetchContext", "PysmoProject"]
 
@@ -75,50 +78,14 @@ def _on_setattr_clear_cache[T](
     return value
 
 
-@define(kw_only=True, frozen=True)
-class FetchContext[TStation: Station, TEvent: Event]:
-    """Context passed to `seismogram_transform` with the downloaded seismogram.
-
-    Bundles the originating [`ProjectEntry`][pysmo.tools.project.ProjectEntry]
-    with what this specific fetch resolved but that doesn't belong on
-    `ProjectEntry` itself. Recomputed fresh on every fetch, never persisted
-    (unlike `entry.checksum`, which is deliberately pinned).
-
-    Note the deliberate naming overlap with `entry.starttime`/`entry.endtime`:
-    those are the entry's possibly-`None` *explicit override* (see
-    [`ProjectEntry`][pysmo.tools.project.ProjectEntry]), while
-    `starttime`/`endtime` here are always-populated and reflect the window
-    that was *actually used*: identical to the entry's own when an explicit
-    override was given, resolved from `predicted` otherwise. A transform
-    wanting "the window this fetch actually covered" should read
-    `context.starttime`/`context.endtime`, not
-    `context.entry.starttime`/`context.entry.endtime`.
-    """
-
-    entry: ProjectEntry[TStation, TEvent]
-    """The entry this seismogram was fetched for."""
-
-    starttime: pd.Timestamp
-    """Absolute start of the window actually used for this fetch."""
-
-    endtime: pd.Timestamp
-    """Absolute end of the window actually used for this fetch."""
-
-    predicted: pd.Timestamp | None
-    """Predicted phase arrival used to derive the window, or `None` if
-    `entry.starttime`/`entry.endtime` were used directly."""
-
-
-type _EventKey = tuple[float, float, float, pd.Timestamp] | None
-"""(latitude, longitude, depth, time): everything `_resolve_window` actually
-reads off `Event` (via `haversine` and `entry.event.time`), not just `time`.
-Keying on `time` alone would collide two distinct events sharing an origin
-time but not a location, since they resolve to different windows via
-`haversine`."""
-
-type _CacheKey = tuple[
-    str, str, str, str, _EventKey, pd.Timestamp | None, pd.Timestamp | None
-]
+type _CacheKey = str
+"""An [`entry.identity`][pysmo.tools.project.ProjectEntry.identity] string:
+the entry's content fingerprint (station codes, event hypocentre, explicit
+window). A `WindowResolver` is a pure function of the entry, so two entries
+with the same identity resolve to the same window; keying on identity is
+strategy-agnostic (it encodes nothing about what a resolver reads) yet keeps
+distinct events apart, which a resolved-window key does not for two explicit
+windows that happen to coincide."""
 
 
 @define(kw_only=True)
@@ -126,12 +93,12 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
     """Declares station/event data to fetch on demand and transform into `TSeismogram`.
 
     A `PysmoProject` holds a flat list of
-    [`ProjectEntry`][pysmo.tools.project.ProjectEntry] objects plus the
-    parameters needed to resolve each entry's fetch window and the
-    `seismogram_transform` callable that turns a freshly downloaded
-    [`Seismogram`][pysmo.Seismogram] into the caller's target type
-    `TSeismogram`. No waveform data are stored on the instance between calls
-    beyond an in-memory cache of already-fetched-and-transformed results.
+    [`ProjectEntry`][pysmo.tools.project.ProjectEntry] objects plus three
+    pluggable callables: `window` resolves each entry's fetch window,
+    `fetch_seismogram` downloads the trace, and `seismogram_transform` turns
+    it into the caller's target type `TSeismogram`. No waveform data are
+    stored on the instance between calls beyond an in-memory cache of
+    already-fetched-and-transformed results.
 
     Generic over the station and event types of its `entries` (matching
     [`ProjectEntry`][pysmo.tools.project.ProjectEntry]'s parameter order)
@@ -157,13 +124,13 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
         two threads racing the same not-yet-cached entry both still fetch
         before one result wins and is cached.
 
-        Reassigning a window parameter (`phase`, `pre_pick`, …) on one
+        Reassigning `window` (or any other cache-affecting field) on one
         thread while another is mid-fetch is also safe: the in-flight fetch
         still returns a result, it just isn't cached (the next call
         recomputes it with the current parameters).
     """
 
-    _FORMAT_VERSION: ClassVar[int] = 1
+    _FORMAT_VERSION: ClassVar[int] = 2
 
     entries: list[ProjectEntry[TStation, TEvent]] = field(
         factory=list, on_setattr=setters.pipe(setters.convert, _on_setattr_clear_cache)
@@ -179,9 +146,7 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
     keyed by entry content).
     """
 
-    seismogram_transform: Callable[
-        [Seismogram, FetchContext[TStation, TEvent]], TSeismogram
-    ] = field(
+    seismogram_transform: SeismogramTransform[TStation, TEvent, TSeismogram] = field(
         # The default returns `MiniSeismogram`, which is `TSeismogram`'s own
         # default, but mypy still can't match a concrete return against the
         # bare type parameter in the class body.
@@ -190,40 +155,26 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
     )
     """Convert a freshly downloaded seismogram into the target type `TSeismogram`.
 
-    Called with the downloaded seismogram and a
-    [`FetchContext`][pysmo.tools.project.FetchContext] carrying the
-    originating entry and this fetch's resolved window and predicted arrival.
-    Defaults to returning the raw trace as a
-    [`MiniSeismogram`][pysmo.MiniSeismogram]. Response removal, detrending
-    and resampling are never applied unless a custom transform does so
-    explicitly, and a custom transform is where that ordinary data
-    preparation belongs: it is the one place every fetch already passes
-    through, and it is free to do anything else it needs, including its own
-    additional fetches (e.g. instrument response metadata via
-    [`StationXML.fetch`][pysmo.classes.StationXML.fetch], demonstrated in the
-    [module documentation][pysmo.tools.project]'s own example; this design
-    does not fetch or know about response data itself, deliberately).
-
-    To be pickled with its `PysmoProject`, it must be a top-level function in
-    an importable module, not a lambda or closure. A callable `attrs` class
-    with only picklable fields (same example) is the alternative once the
-    transform needs its own configuration.
+    Any [`SeismogramTransform`][pysmo.tools.project.SeismogramTransform] (see
+    there for the call contract). Defaults to returning the raw trace as a
+    [`MiniSeismogram`][pysmo.MiniSeismogram], with no processing: a custom
+    transform is where response removal, detrending and resampling belong,
+    and it may issue its own additional fetches, as the
+    [module documentation][pysmo.tools.project]'s example does for instrument
+    response metadata. A callable `attrs` class with only picklable fields is
+    the way to give the transform its own configuration.
     """
 
-    fetch_seismogram: Callable[[Station, pd.Timestamp, pd.Timestamp], Seismogram] = (
-        field(
-            default=_default_fetch_seismogram,
-            on_setattr=setters.pipe(setters.convert, _on_setattr_clear_cache),
-        )
+    fetch_seismogram: SeismogramFetcher = field(
+        default=_default_fetch_seismogram,
+        on_setattr=setters.pipe(setters.convert, _on_setattr_clear_cache),
     )
     """Download a seismogram for a station and absolute time window.
 
-    Defaults to a private helper wrapping
+    Any [`SeismogramFetcher`][pysmo.tools.project.SeismogramFetcher] (see
+    there for the call contract). Defaults to a private helper wrapping
     [`MSeed.fetch`][pysmo.classes.MSeed.fetch], the explicit "always fresh,
-    never cached" choice. The fetched trace is normalised to a
-    [`MiniSeismogram`][pysmo.MiniSeismogram] by the default
-    `seismogram_transform`, so the project's return type is unchanged by the
-    fetch format.
+    never cached" choice.
 
     For any project where reproducibility matters, substitute a
     [`SqliteArchiveFetcher`][pysmo.tools.archive.SqliteArchiveFetcher]
@@ -236,66 +187,21 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
     to rule out. It only pins the waveform, though: see the
     [module documentation][pysmo.tools.project]'s second example for the
     gotcha it does not cover, `seismogram_transform` making its own
-    additional fetches. Any other callable of the right shape (e.g. one
-    wrapping [`SAC.fetch`][pysmo.classes.SAC.fetch]) also works, changing the
-    retrieval path without subclassing. Must be picklable by reference (a
-    top-level function, or an attrs instance with only picklable fields, not
-    a lambda or closure), the same constraint as `seismogram_transform`.
+    additional fetches.
     """
 
-    phase: str = field(
-        default="P", on_setattr=setters.pipe(setters.convert, _on_setattr_clear_cache)
-    )
-    """Seismic phase used to derive a window from an entry's `event`.
-
-    With the default `travel_time_backend` this must be one of the phases
-    in [`Phase`][pysmo.tools.traveltime.Phase]; any other name raises when
-    a window is next resolved. A custom backend may accept a wider set.
-    """
-
-    pre_pick: NonPositiveTimedelta = field(
-        default=pd.Timedelta(minutes=-2),
-        converter=convert_to_timedelta,
-        validator=[
-            validators.instance_of(pd.Timedelta),
-            validators.le(pd.Timedelta(0)),
-        ],
-        on_setattr=setters.pipe(
-            setters.convert, setters.validate, _on_setattr_clear_cache
-        ),
-    )
-    """Offset from the predicted arrival to the window start; zero or negative."""
-
-    post_pick: PositiveTimedelta = field(
-        default=pd.Timedelta(minutes=8),
-        converter=convert_to_timedelta,
-        validator=[
-            validators.instance_of(pd.Timedelta),
-            validators.gt(pd.Timedelta(0)),
-        ],
-        on_setattr=setters.pipe(
-            setters.convert, setters.validate, _on_setattr_clear_cache
-        ),
-    )
-    """Offset from the predicted arrival to the window end. Must be positive."""
-
-    travel_time_backend: TravelTimeBackend = field(
-        default=builtin_backend,
+    window: WindowResolver[TStation, TEvent] = field(
+        default=PhaseWindow(),
         on_setattr=setters.pipe(setters.convert, _on_setattr_clear_cache),
     )
-    """Predicts the phase arrival a window is built around.
+    """Resolve an entry's fetch window when it carries no explicit one.
 
-    Defaults to pysmo's built-in solver,
-    [`travel_times`][pysmo.tools.traveltime.travel_times]. Replace it with
-    any callable of the same shape
-    ([`TravelTimeBackend`][pysmo.tools.traveltime.TravelTimeBackend]), for
-    another velocity model (see the
-    [module documentation][pysmo.tools.project]), a phase the built-in
-    solver does not cover, or arrival times from an external source. Must
-    be picklable: a top-level function, a
-    [`functools.partial`][] of one, or an attrs instance
-    with only picklable fields, like `fetch_seismogram`; not a lambda or
-    closure.
+    Any [`WindowResolver`][pysmo.tools.project.WindowResolver] (see there for
+    the call contract). Defaults to
+    [`PhaseWindow`][pysmo.tools.project.PhaseWindow], which places the window
+    around a predicted phase arrival. An entry with an explicit
+    `starttime`/`endtime` bypasses this entirely, so a custom resolver only
+    ever handles the event-derived case.
     """
 
     on_checksum_mismatch: Literal["warn", "raise", "ignore"] = field(
@@ -359,12 +265,10 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
 
         Cleared automatically whenever
         [`entries`][pysmo.tools.project.PysmoProject.entries],
+        [`window`][pysmo.tools.project.PysmoProject.window],
         [`seismogram_transform`][pysmo.tools.project.PysmoProject.seismogram_transform],
-        [`fetch_seismogram`][pysmo.tools.project.PysmoProject.fetch_seismogram],
-        [`phase`][pysmo.tools.project.PysmoProject.phase],
-        [`pre_pick`][pysmo.tools.project.PysmoProject.pre_pick],
-        [`post_pick`][pysmo.tools.project.PysmoProject.post_pick], or
-        [`travel_time_backend`][pysmo.tools.project.PysmoProject.travel_time_backend]
+        or
+        [`fetch_seismogram`][pysmo.tools.project.PysmoProject.fetch_seismogram]
         is *reassigned*.
 
         Call this manually after any in-place mutation of
@@ -375,38 +279,6 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
         with self._lock:
             self._cache.clear()
             self._cache_generation += 1
-
-    def _resolve_window(
-        self, entry: ProjectEntry[TStation, TEvent]
-    ) -> tuple[pd.Timestamp, pd.Timestamp, pd.Timestamp | None]:
-        """Resolve the absolute fetch window and predicted arrival for one entry.
-
-        Returns:
-            `(starttime, endtime, predicted_arrival)`; `predicted_arrival`
-            is `None` when `entry.starttime`/`entry.endtime` were used
-            directly rather than derived from `entry.event`.
-
-        Raises:
-            ValueError: If `entry` has neither a usable explicit window nor
-                an event to derive one from, or if no `phase` arrival is
-                predicted for this station/event geometry.
-        """
-        if entry.starttime is not None and entry.endtime is not None:
-            return entry.starttime, entry.endtime, None
-        if entry.event is not None:
-            dist = haversine(entry.event, entry.station)
-            tt = self.travel_time_backend(
-                depth=entry.event.depth, distance=dist, phases=[self.phase]
-            )
-            if self.phase not in tt:
-                raise ValueError(
-                    f"No {self.phase!r} arrival predicted for "
-                    + f"{entry.station.network}.{entry.station.name} at this "
-                    + "distance/depth."
-                )
-            predicted = entry.event.time + tt[self.phase]
-            return predicted + self.pre_pick, predicted + self.post_pick, predicted
-        raise ValueError("ProjectEntry needs either an explicit window or an event.")
 
     def _fetch(
         self, entry: ProjectEntry[TStation, TEvent], *, _stacklevel: int = 3
@@ -421,49 +293,43 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
             entry: The station/event/window selection to fetch.
 
         Returns:
-            The transformed result for `entry`, from cache if this exact
-            entry has been fetched before.
+            The transformed result for `entry`, from cache if an entry with
+            the same [`identity`][pysmo.tools.project.ProjectEntry.identity]
+            has been fetched before.
 
         Raises:
-            ValueError: If `entry` has neither a usable window nor an event
-                (via `_resolve_window`); if the underlying fetch raises
-                (e.g. no waveform data for the resolved window); or if the
-                checksum no longer matches and `on_checksum_mismatch="raise"`.
+            ValueError: If `window` cannot resolve a window for `entry`; if
+                the underlying fetch raises (e.g. no waveform data for the
+                resolved window); or if the checksum no longer matches and
+                `on_checksum_mismatch="raise"`.
         """
-        event_key: _EventKey = (
-            (
-                entry.event.latitude,
-                entry.event.longitude,
-                entry.event.depth,
-                entry.event.time,
-            )
-            if entry.event is not None
-            else None
-        )
-        key: _CacheKey = (
-            entry.station.network,
-            entry.station.name,
-            entry.station.location,
-            entry.station.channel,
-            event_key,
-            entry.starttime,
-            entry.endtime,
-        )
+        key: _CacheKey = entry_identity(entry)
         with self._lock:
             cached = self._cache.get(key)
             generation = self._cache_generation
         if cached is None:
-            # Deliberately outside the lock; see the class docstring's
-            # thread-safety note: two threads racing the same not-yet-cached
-            # key both fetch here (a stampede) before one result wins.
-            starttime, endtime, predicted = self._resolve_window(entry)
-            seismogram = self.fetch_seismogram(entry.station, starttime, endtime)
+            # Resolve the window only on a miss: an explicit window on the
+            # entry wins (it is entry data, not resolution policy), else the
+            # `window` resolver derives one. Resolution and the fetch both
+            # run outside the lock (see the class docstring's thread-safety
+            # note): a concurrent `self.window` reassignment is a tolerated
+            # torn read, `generation` (read above) guards the write-back, and
+            # two threads racing the same key both fetch before one wins.
+            if entry.starttime is not None and entry.endtime is not None:
+                window = WindowResult(
+                    starttime=entry.starttime, endtime=entry.endtime, reference=None
+                )
+            else:
+                window = self.window(entry)
+            seismogram = self.fetch_seismogram(
+                entry.station, window.starttime, window.endtime
+            )
             checksum = _checksum(seismogram)
             context = FetchContext(
                 entry=entry,
-                starttime=starttime,
-                endtime=endtime,
-                predicted=predicted,
+                starttime=window.starttime,
+                endtime=window.endtime,
+                reference=window.reference,
             )
             fresh = (checksum, self.seismogram_transform(seismogram, context))
             with self._lock:
@@ -471,8 +337,8 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
                     cached = self._cache.setdefault(key, fresh)
                 else:
                     # A parameter changed (clearing the cache) while this
-                    # fetch was in flight: `key` doesn't encode it, so return
-                    # this result once without caching it under a stale key.
+                    # fetch was in flight: return this result once without
+                    # caching it under a now-stale key.
                     cached = fresh
 
         checksum, result = cached
@@ -533,14 +399,14 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
     def resolution_context_digest(self) -> str:
         """Digest over the project parameters that determine fetched content.
 
-        Covers `phase`, `pre_pick`, `post_pick`, `travel_time_backend`, and
-        `seismogram_transform`. Reassigning `fetch_seismogram` (e.g. to an
-        offline archive cache) leaves the digest unchanged.
+        Covers `window` and `seismogram_transform`. Reassigning
+        `fetch_seismogram` (e.g. to an offline archive cache) leaves the
+        digest unchanged.
 
         Examples:
             >>> from pysmo.tools.project import PysmoProject
             >>> project = PysmoProject()
-            >>> project.resolution_context_digest.startswith("rc1:")
+            >>> project.resolution_context_digest.startswith("rc2:")
             True
             >>> len(project.resolution_context_digest)
             68

--- a/src/pysmo/tools/project/_types.py
+++ b/src/pysmo/tools/project/_types.py
@@ -1,0 +1,136 @@
+"""Result and callable-seam types shared across the project tool.
+
+[`PysmoProject`][pysmo.tools.project.PysmoProject] has three pluggable
+seams, each a plain callable:
+
+- [`WindowResolver`][pysmo.tools.project.WindowResolver] turns an entry into
+  an absolute fetch window.
+- [`SeismogramFetcher`][pysmo.tools.project.SeismogramFetcher] downloads a
+  trace for a station and window.
+- [`SeismogramTransform`][pysmo.tools.project.SeismogramTransform] converts a
+  downloaded trace into the project's target type.
+
+Each is a `Callable` type alias rather than a `Protocol`: none of the call
+shapes needs keyword-only parameters or non-`__call__` attributes, and
+[`PhaseWindow`][pysmo.tools.project.PhaseWindow] already ships as a concrete
+`WindowResolver` to copy.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pandas as pd
+from attrs import define
+
+from pysmo import Event, Seismogram, Station
+
+from ._entry import ProjectEntry
+
+__all__ = [
+    "FetchContext",
+    "SeismogramFetcher",
+    "SeismogramTransform",
+    "WindowResolver",
+    "WindowResult",
+]
+
+
+@define(kw_only=True, frozen=True)
+class WindowResult:
+    """The absolute fetch window resolved for one entry.
+
+    Returned by a [`WindowResolver`][pysmo.tools.project.WindowResolver].
+    """
+
+    starttime: pd.Timestamp
+    """Absolute start of the window."""
+
+    endtime: pd.Timestamp
+    """Absolute end of the window."""
+
+    reference: pd.Timestamp | None
+    """Timestamp the window was placed around (a predicted phase arrival for
+    [`PhaseWindow`][pysmo.tools.project.PhaseWindow]), or `None` when the
+    window came from an entry's explicit `starttime`/`endtime`."""
+
+
+@define(kw_only=True, frozen=True)
+class FetchContext[TStation: Station, TEvent: Event]:
+    """Context passed to `seismogram_transform` with the downloaded seismogram.
+
+    Bundles the originating [`ProjectEntry`][pysmo.tools.project.ProjectEntry]
+    with what this specific fetch resolved but that doesn't belong on
+    `ProjectEntry` itself. Recomputed fresh on every fetch, never persisted
+    (unlike `entry.checksum`, which is deliberately pinned).
+
+    Note the deliberate naming overlap with `entry.starttime`/`entry.endtime`:
+    those are the entry's possibly-`None` *explicit override* (see
+    [`ProjectEntry`][pysmo.tools.project.ProjectEntry]), while
+    `starttime`/`endtime` here are always-populated and reflect the window
+    that was *actually used*: identical to the entry's own when an explicit
+    override was given, resolved by the project's `window` otherwise. A
+    transform wanting "the window this fetch actually covered" should read
+    `context.starttime`/`context.endtime`, not
+    `context.entry.starttime`/`context.entry.endtime`.
+    """
+
+    entry: ProjectEntry[TStation, TEvent]
+    """The entry this seismogram was fetched for."""
+
+    starttime: pd.Timestamp
+    """Absolute start of the window actually used for this fetch."""
+
+    endtime: pd.Timestamp
+    """Absolute end of the window actually used for this fetch."""
+
+    reference: pd.Timestamp | None
+    """Timestamp the window was placed around (a predicted phase arrival for
+    the default `window`), or `None` if `entry.starttime`/`entry.endtime`
+    were used directly."""
+
+
+type WindowResolver[TStation: Station, TEvent: Event] = Callable[
+    [ProjectEntry[TStation, TEvent]], WindowResult
+]
+"""Resolve an entry's absolute fetch window.
+
+Called with a single [`ProjectEntry`][pysmo.tools.project.ProjectEntry] and
+returns a [`WindowResult`][pysmo.tools.project.WindowResult]. Raises
+`ValueError` when no window can be resolved (no predicted arrival for the
+station/event geometry, or a required event missing).
+
+Only ever called for entries *without* an explicit `starttime`/`endtime`
+pair: [`PysmoProject`][pysmo.tools.project.PysmoProject] resolves that case
+itself before consulting the resolver, so a custom resolver never has to
+reimplement it. [`PhaseWindow`][pysmo.tools.project.PhaseWindow] is the
+default. Must be picklable by reference (a top-level function, or an attrs
+instance with only picklable fields, not a lambda or closure), the same
+constraint as the other two seams.
+"""
+
+type SeismogramFetcher = Callable[[Station, pd.Timestamp, pd.Timestamp], Seismogram]
+"""Download a seismogram for a station and absolute time window.
+
+Called with a [`Station`][pysmo.Station] and the resolved
+`starttime`/`endtime`, and returns a [`Seismogram`][pysmo.Seismogram].
+"Always fresh" by contract: [`PysmoProject`][pysmo.tools.project.PysmoProject]
+keeps its own in-memory cache, so a fetcher normally hits the network every
+time rather than consulting a cache of its own. Swap in a
+[`SqliteArchiveFetcher`][pysmo.tools.archive.SqliteArchiveFetcher] for a
+reproducible on-disk archive instead. Must be picklable by reference.
+"""
+
+type SeismogramTransform[TStation: Station, TEvent: Event, TSeismogram] = Callable[
+    [Seismogram, FetchContext[TStation, TEvent]], TSeismogram
+]
+"""Convert a freshly downloaded seismogram into the project's target type.
+
+Called with the downloaded [`Seismogram`][pysmo.Seismogram] and a
+[`FetchContext`][pysmo.tools.project.FetchContext] carrying the originating
+entry and this fetch's resolved window. The one place ordinary data
+preparation (response removal, detrending, resampling) belongs, and free to
+issue its own additional fetches (e.g. instrument response metadata via
+[`StationXML.fetch`][pysmo.classes.StationXML.fetch]). Must be picklable by
+reference.
+"""

--- a/tests/tools/project/test_identity.py
+++ b/tests/tools/project/test_identity.py
@@ -12,6 +12,7 @@ import pytest
 from pysmo import MiniEvent, MiniSeismogram, MiniStation, Seismogram, Station
 from pysmo.tools.project import (
     FetchContext,
+    PhaseWindow,
     ProjectEntry,
     PysmoProject,
     callable_identity,
@@ -371,6 +372,18 @@ class TestCallableIdentity:
         assert callable_identity(inst1) != callable_identity(inst3)
         assert callable_identity(inst1).startswith("attrs:")
 
+    def test_attrs_instance_with_nested_callable_field(self) -> None:
+        # PhaseWindow holds `travel_time_backend` as a functools.partial,
+        # which `_prepare_json_value` cannot reduce; the attrs branch must
+        # recurse into it.
+        base = PhaseWindow()
+        assert callable_identity(base) == callable_identity(PhaseWindow())
+        swapped = PhaseWindow(
+            travel_time_backend=functools.partial(travel_times, model="ak135")
+        )
+        assert callable_identity(swapped) != callable_identity(base)
+        assert callable_identity(base).startswith("attrs:")
+
     def test_unsupported_callables_raise_type_error(self) -> None:
         # Lambda
         with pytest.raises(TypeError, match="Closures and lambdas are not supported"):
@@ -405,25 +418,31 @@ class TestResolutionContextDigest:
     def test_format_and_stability(self) -> None:
         project: ProjectT = PysmoProject()
         digest = resolution_context_digest(project)
-        assert re.match(r"^rc1:[0-9a-f]{64}$", digest) is not None
-        assert digest.startswith("rc1:")
+        assert re.match(r"^rc2:[0-9a-f]{64}$", digest) is not None
+        assert digest.startswith("rc2:")
         assert len(digest) == 68
 
     def test_digest_changes_on_relevant_parameters(self) -> None:
-        p1: ProjectT = PysmoProject(phase="P")
+        p1: ProjectT = PysmoProject(window=PhaseWindow(phase="P"))
         d1 = resolution_context_digest(p1)
 
-        p2: ProjectT = PysmoProject(phase="S")
+        p2: ProjectT = PysmoProject(window=PhaseWindow(phase="S"))
         assert resolution_context_digest(p2) != d1
 
-        p3: ProjectT = PysmoProject(pre_pick=pd.Timedelta(minutes=-3))
+        p3: ProjectT = PysmoProject(
+            window=PhaseWindow(pre_pick=pd.Timedelta(minutes=-3))
+        )
         assert resolution_context_digest(p3) != d1
 
-        p4: ProjectT = PysmoProject(post_pick=pd.Timedelta(minutes=10))
+        p4: ProjectT = PysmoProject(
+            window=PhaseWindow(post_pick=pd.Timedelta(minutes=10))
+        )
         assert resolution_context_digest(p4) != d1
 
         p5: ProjectT = PysmoProject(
-            travel_time_backend=functools.partial(travel_times, model="ak135")
+            window=PhaseWindow(
+                travel_time_backend=functools.partial(travel_times, model="ak135")
+            )
         )
         assert resolution_context_digest(p5) != d1
 

--- a/tests/tools/project/test_project.py
+++ b/tests/tools/project/test_project.py
@@ -15,9 +15,11 @@ import pytest
 from pysmo import Event, MiniEvent, MiniSeismogram, MiniStation, Seismogram, Station
 from pysmo.tools.project import (
     FetchContext,
+    PhaseWindow,
     ProjectEntry,
     PysmoProject,
     UnknownEntryIdentity,
+    WindowResult,
     build_entries,
 )
 
@@ -68,17 +70,10 @@ def fake_travel_time_backend(
     return {"P": pd.Timedelta(seconds=100.0), "S": pd.Timedelta(seconds=200.0)}
 
 
-def other_travel_time_backend(
-    *, depth: float, distance: float, phases: Sequence[str]
-) -> dict[str, pd.Timedelta]:
-    return {"P": pd.Timedelta(seconds=300.0), "S": pd.Timedelta(seconds=400.0)}
-
-
-def no_arrival_travel_time_backend(
-    *, depth: float, distance: float, phases: Sequence[str]
-) -> dict[str, pd.Timedelta]:
-    """Stands in for a geometry with no predicted arrival for the requested phase."""
-    return {}
+def phase_window(**kwargs: object) -> PhaseWindow:
+    """A `PhaseWindow` on the fake backend, unless a kwarg overrides it."""
+    kwargs.setdefault("travel_time_backend", fake_travel_time_backend)
+    return PhaseWindow(**kwargs)  # type: ignore[arg-type]
 
 
 @pytest.fixture(autouse=True)
@@ -93,7 +88,7 @@ def project(station_anmo: MiniStation, event_maule: MiniEvent) -> ProjectT:
         entries=[ProjectEntry(station=station_anmo, event=event_maule)],
         seismogram_transform=identity_transform,
         fetch_seismogram=fake_fetch_seismogram,
-        travel_time_backend=fake_travel_time_backend,
+        window=phase_window(),
     )
 
 
@@ -131,84 +126,6 @@ class TestProjectEntry:
         assert entry.starttime == pd.Timestamp("2024-01-01T00:00:00Z")
         assert entry.endtime == pd.Timestamp("2024-01-01T00:01:00Z")
         assert entry.starttime.tz is not None
-
-
-class TestResolveWindow:
-    def test_explicit_window_wins_over_event(
-        self,
-        project: ProjectT,
-        station_anmo: MiniStation,
-        event_maule: MiniEvent,
-    ) -> None:
-        explicit_start = pd.Timestamp("2020-01-01T00:00:00Z")
-        explicit_end = pd.Timestamp("2020-01-01T00:01:00Z")
-        entry = ProjectEntry(
-            station=station_anmo,
-            event=event_maule,
-            starttime=explicit_start,
-            endtime=explicit_end,
-        )
-        starttime, endtime, predicted = project._resolve_window(entry)
-        assert (starttime, endtime, predicted) == (explicit_start, explicit_end, None)
-
-    def test_window_derived_from_event(
-        self, project: ProjectT, station_anmo: MiniStation, event_maule: MiniEvent
-    ) -> None:
-        entry = ProjectEntry(station=station_anmo, event=event_maule)
-        starttime, endtime, predicted = project._resolve_window(entry)
-
-        expected_predicted = event_maule.time + pd.Timedelta(seconds=100.0)
-        assert predicted == expected_predicted
-        assert starttime == expected_predicted + project.pre_pick
-        assert endtime == expected_predicted + project.post_pick
-
-    def test_neither_window_nor_event_raises(
-        self, project: ProjectT, station_anmo: MiniStation, event_maule: MiniEvent
-    ) -> None:
-        # A bare entry is rejected at construction; _resolve_window keeps its
-        # own guard for an entry mutated back to that state afterwards.
-        entry = ProjectEntry(station=station_anmo, event=event_maule)
-        entry.event = None
-        with pytest.raises(ValueError, match="explicit window or an event"):
-            project._resolve_window(entry)
-
-    def test_no_predicted_arrival_for_phase_raises_value_error(
-        self, station_anmo: MiniStation, event_maule: MiniEvent
-    ) -> None:
-        project: ProjectT = PysmoProject(
-            entries=[],
-            seismogram_transform=identity_transform,
-            fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=no_arrival_travel_time_backend,
-        )
-        entry = ProjectEntry(station=station_anmo, event=event_maule)
-        with pytest.raises(ValueError, match="No 'P' arrival predicted"):
-            project._resolve_window(entry)
-
-
-class TestPickPickValidators:
-    def test_pre_pick_zero_is_valid(self) -> None:
-        PysmoProject(seismogram_transform=identity_transform, pre_pick=pd.Timedelta(0))
-
-    def test_pre_pick_positive_raises(self) -> None:
-        with pytest.raises(ValueError):
-            PysmoProject(
-                seismogram_transform=identity_transform,
-                pre_pick=pd.Timedelta(seconds=1),
-            )
-
-    def test_post_pick_zero_raises(self) -> None:
-        with pytest.raises(ValueError):
-            PysmoProject(
-                seismogram_transform=identity_transform, post_pick=pd.Timedelta(0)
-            )
-
-    def test_post_pick_negative_raises(self) -> None:
-        with pytest.raises(ValueError):
-            PysmoProject(
-                seismogram_transform=identity_transform,
-                post_pick=pd.Timedelta(seconds=-1),
-            )
 
 
 class TestQuerySurface:
@@ -296,7 +213,7 @@ class TestFetchAll:
             ],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         results = project.fetch_all()
         assert len(results) == 2
@@ -312,6 +229,28 @@ class TestSeismogramCaching:
         project.seismogram(station_anmo, event_maule)
         project.seismogram(station_anmo, event_maule)
         assert len(FETCH_CALLS) == 1
+
+    def test_cache_hit_does_not_re_resolve_the_window(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        calls = {"n": 0}
+        base = phase_window()
+
+        def counting_window(
+            entry: ProjectEntry[MiniStation, MiniEvent],
+        ) -> WindowResult:
+            calls["n"] += 1
+            return base(entry)
+
+        project: ProjectT = PysmoProject(
+            entries=[ProjectEntry(station=station_anmo, event=event_maule)],
+            seismogram_transform=identity_transform,
+            fetch_seismogram=fake_fetch_seismogram,
+            window=counting_window,
+        )
+        project.seismogram(station_anmo, event_maule)
+        project.seismogram(station_anmo, event_maule)
+        assert calls["n"] == 1
 
     def test_distinct_entries_produce_distinct_cache_entries(
         self, station_anmo: MiniStation, event_maule: MiniEvent
@@ -331,7 +270,7 @@ class TestSeismogramCaching:
             ],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         project.seismogram(station_anmo, event_maule)
         project.seismogram(other_channel_station, event_maule)
@@ -352,11 +291,60 @@ class TestSeismogramCaching:
             entries=[event_entry, explicit_entry],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         project._fetch(event_entry)
         project._fetch(explicit_entry)
         assert len(FETCH_CALLS) == 2
+
+    def test_entries_with_the_same_identity_share_one_fetch(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        # Two entries with the same identity (same station and event) share a
+        # single fetch and result.
+        entry_a = ProjectEntry(station=station_anmo, event=event_maule)
+        entry_b = ProjectEntry(station=station_anmo, event=event_maule)
+        project = PysmoProject(
+            entries=[entry_a, entry_b],
+            seismogram_transform=identity_transform,
+            fetch_seismogram=fake_fetch_seismogram,
+            window=phase_window(),
+        )
+        assert project._fetch(entry_a) is project._fetch(entry_b)
+        assert len(FETCH_CALLS) == 1
+
+    def test_same_explicit_window_different_events_not_merged(
+        self, station_anmo: MiniStation, event_maule: MiniEvent, event_other: MiniEvent
+    ) -> None:
+        # Two entries sharing a station and an identical explicit window but
+        # carrying different events stay distinct: a transform reading
+        # context.entry.event must not get one event's result for the other.
+        t0 = pd.Timestamp("2020-01-01T00:00:00Z")
+        t1 = pd.Timestamp("2020-01-01T00:10:00Z")
+        entry_a = ProjectEntry(
+            station=station_anmo, event=event_maule, starttime=t0, endtime=t1
+        )
+        entry_b = ProjectEntry(
+            station=station_anmo, event=event_other, starttime=t0, endtime=t1
+        )
+        seen_events: list[object] = []
+
+        def tag_transform(
+            seismogram: Seismogram, context: FetchContext[MiniStation, MiniEvent]
+        ) -> Seismogram:
+            seen_events.append(context.entry.event)
+            return seismogram
+
+        project = PysmoProject(
+            entries=[entry_a, entry_b],
+            seismogram_transform=tag_transform,
+            fetch_seismogram=fake_fetch_seismogram,
+            window=phase_window(),
+        )
+        project._fetch(entry_a)
+        project._fetch(entry_b)
+        assert len(FETCH_CALLS) == 2
+        assert seen_events == [event_maule, event_other]
 
 
 class TestSeismogramErrors:
@@ -391,39 +379,22 @@ class TestSeismogramErrors:
 
 
 class TestCacheInvalidation:
-    def test_phase_change_triggers_refetch(
+    def test_window_reassignment_triggers_refetch(
         self, project: ProjectT, station_anmo: MiniStation, event_maule: MiniEvent
     ) -> None:
         project.seismogram(station_anmo, event_maule)
-        project.phase = "S"
+        project.window = phase_window(phase="S")
         project.seismogram(station_anmo, event_maule)
         assert len(FETCH_CALLS) == 2
         assert FETCH_CALLS[0][1] != FETCH_CALLS[1][1]
 
-    def test_pre_pick_change_triggers_refetch(
+    def test_window_field_change_triggers_refetch(
         self, project: ProjectT, station_anmo: MiniStation, event_maule: MiniEvent
     ) -> None:
         project.seismogram(station_anmo, event_maule)
-        project.pre_pick = pd.Timedelta(minutes=-1)
+        project.window = phase_window(pre_pick=pd.Timedelta(minutes=-1))
         project.seismogram(station_anmo, event_maule)
         assert len(FETCH_CALLS) == 2
-
-    def test_post_pick_change_triggers_refetch(
-        self, project: ProjectT, station_anmo: MiniStation, event_maule: MiniEvent
-    ) -> None:
-        project.seismogram(station_anmo, event_maule)
-        project.post_pick = pd.Timedelta(minutes=9)
-        project.seismogram(station_anmo, event_maule)
-        assert len(FETCH_CALLS) == 2
-
-    def test_travel_time_backend_change_triggers_refetch(
-        self, project: ProjectT, station_anmo: MiniStation, event_maule: MiniEvent
-    ) -> None:
-        project.seismogram(station_anmo, event_maule)
-        project.travel_time_backend = other_travel_time_backend
-        project.seismogram(station_anmo, event_maule)
-        assert len(FETCH_CALLS) == 2
-        assert FETCH_CALLS[0][1] != FETCH_CALLS[1][1]
 
     def test_fetch_seismogram_change_triggers_refetch(
         self, project: ProjectT, station_anmo: MiniStation, event_maule: MiniEvent
@@ -445,7 +416,7 @@ class TestCacheInvalidation:
         self, project: ProjectT, station_anmo: MiniStation, event_maule: MiniEvent
     ) -> None:
         project.seismogram(station_anmo, event_maule)
-        project.phase = "P"  # same value it already was
+        project.window = phase_window()  # equal to the value it already was
         project.seismogram(station_anmo, event_maule)
         assert len(FETCH_CALLS) == 1
 
@@ -453,11 +424,12 @@ class TestCacheInvalidation:
         self, project: ProjectT, station_anmo: MiniStation, event_maule: MiniEvent
     ) -> None:
         project.seismogram(station_anmo, event_maule)
-        # A different Timedelta object with an equal value -- exercises the
-        # `==` branch, not the `is` identity short-circuit.
-        assert project.pre_pick == pd.Timedelta(seconds=-120)
-        assert project.pre_pick is not pd.Timedelta(seconds=-120)
-        project.pre_pick = pd.Timedelta(seconds=-120)
+        # A fresh PhaseWindow with equal fields -- exercises the `==` branch,
+        # not the `is` identity short-circuit.
+        replacement = phase_window()
+        assert project.window == replacement
+        assert project.window is not replacement
+        project.window = replacement
         project.seismogram(station_anmo, event_maule)
         assert len(FETCH_CALLS) == 1
 
@@ -482,7 +454,7 @@ class TestSeismogramsFor:
             ],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         results = project.seismograms_for(event_maule)
         assert len(results) == 2
@@ -517,7 +489,7 @@ class TestGet:
             entries=[entry1, entry2],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
 
         # Cold project, fetch only entry1 by identity
@@ -551,7 +523,7 @@ class TestGet:
             entries=[entry1, entry2],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         assert entry1.identity == entry2.identity
         with pytest.raises(
@@ -568,7 +540,7 @@ class TestPickling:
             entries=[ProjectEntry(station=station_anmo, event=event_maule)],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         project.seismogram(station_anmo, event_maule)
         assert len(project._cache) == 1
@@ -592,13 +564,13 @@ class TestPickling:
             entries=entries,
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         unused = PysmoProject(
             entries=entries,
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         used.seismogram(station_anmo, event_maule)  # populates used._cache only
 
@@ -611,12 +583,12 @@ class TestPickling:
             entries=[ProjectEntry(station=station_anmo, event=event_maule)],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         state = project.__getstate__()
         state["_format_version"] = 999
         with pytest.raises(
-            ValueError, match=r"state format v999; this pysmo .* uses v1"
+            ValueError, match=r"state format v999; this pysmo .* uses v2"
         ):
             project.__setstate__(state)
 
@@ -627,11 +599,11 @@ class TestPickling:
             entries=[ProjectEntry(station=station_anmo, event=event_maule)],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         state = project.__getstate__()
         del state["_format_version"]
-        with pytest.raises(ValueError, match=r"state format v0; this pysmo .* uses v1"):
+        with pytest.raises(ValueError, match=r"state format v0; this pysmo .* uses v2"):
             project.__setstate__(state)
 
 
@@ -649,7 +621,7 @@ class TestThreadSafety:
             entries=[ProjectEntry(station=station_anmo, event=event_maule)],
             seismogram_transform=identity_transform,
             fetch_seismogram=slow_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         results: list[Seismogram] = []
         results_lock = threading.Lock()
@@ -686,7 +658,7 @@ class TestThreadSafety:
             entries=[ProjectEntry(station=station_anmo, event=event_maule)],
             seismogram_transform=identity_transform,
             fetch_seismogram=blocking_fetch,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         results: list[Seismogram] = []
 
@@ -696,7 +668,7 @@ class TestThreadSafety:
         thread = threading.Thread(target=worker)
         thread.start()
         assert fetch_started.wait(timeout=5)
-        project.phase = "S"  # clears the cache and bumps the generation
+        project.window = phase_window(phase="S")  # clears cache, bumps generation
         may_finish.set()
         thread.join(timeout=5)
 
@@ -724,7 +696,7 @@ class TestChecksum:
             entries=[ProjectEntry(station=station_anmo, event=event_maule)],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         project.seismogram(station_anmo, event_maule)
         original_checksum = project.entries[0].checksum
@@ -745,7 +717,7 @@ class TestChecksum:
             entries=[entry],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
             on_checksum_mismatch=policy,
         )
         project.seismogram(station_anmo, event_maule)
@@ -773,7 +745,7 @@ class TestChecksum:
             entries=[entry],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         project.seismogram(station_anmo, event_maule)
         FETCH_DATA_OVERRIDE[station_anmo.name] = [9.0, 9.0, 9.0]
@@ -794,7 +766,7 @@ class TestChecksum:
             entries=[entry],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         project.seismogram(station_anmo, event_maule)
         FETCH_DATA_OVERRIDE[station_anmo.name] = [9.0, 9.0, 9.0]
@@ -824,7 +796,7 @@ def test_default_fetch_seismogram_uses_miniseed(
 
     project = PysmoProject(
         entries=[ProjectEntry(station=station_anmo, event=event_maule)],
-        travel_time_backend=fake_travel_time_backend,
+        window=phase_window(),
     )
     seismogram = project.seismogram(station_anmo, event_maule)
 
@@ -853,26 +825,25 @@ class TestProjectResolutionContextDigest:
             entries=[ProjectEntry(station=station_anmo, event=event_maule)],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         d1 = project.resolution_context_digest
 
         project.fetch_seismogram = other_fake_fetch_seismogram
         assert project.resolution_context_digest == d1
 
-    def test_digest_changes_on_phase_swap(
+    def test_digest_changes_on_window_swap(
         self, station_anmo: MiniStation, event_maule: MiniEvent
     ) -> None:
         project = PysmoProject(
             entries=[ProjectEntry(station=station_anmo, event=event_maule)],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
-            phase="P",
+            window=phase_window(phase="P"),
         )
         d1 = project.resolution_context_digest
 
-        project.phase = "S"
+        project.window = phase_window(phase="S")
         assert project.resolution_context_digest != d1
 
     def test_digest_changes_on_transform_swap(
@@ -882,7 +853,7 @@ class TestProjectResolutionContextDigest:
             entries=[ProjectEntry(station=station_anmo, event=event_maule)],
             seismogram_transform=identity_transform,
             fetch_seismogram=fake_fetch_seismogram,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         d1 = project.resolution_context_digest
 
@@ -952,7 +923,7 @@ class TestBuildEntries:
             entries=build_entries([station_anmo], [event_maule]),
             fetch_seismogram=fake_fetch_seismogram,
             seismogram_transform=identity_transform,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         first = project.seismogram(station_anmo, event_maule)
 
@@ -986,7 +957,7 @@ class TestBuildEntries:
             entries=build_entries([station_anmo, station_cacb], [event_maule]),
             fetch_seismogram=fake_fetch_seismogram,
             seismogram_transform=identity_transform,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         anmo_result = project.seismogram(station_anmo, event_maule)
         cacb_result = project.seismogram(station_cacb, event_maule)
@@ -1015,7 +986,7 @@ class TestBuildEntries:
             entries=build_entries([station_anmo, station_cacb], [event_maule]),
             fetch_seismogram=fake_fetch_seismogram,
             seismogram_transform=identity_transform,
-            travel_time_backend=fake_travel_time_backend,
+            window=phase_window(),
         )
         project.fetch_all()
 

--- a/tests/tools/project/test_window.py
+++ b/tests/tools/project/test_window.py
@@ -1,0 +1,162 @@
+"""Tests for WindowResult, PhaseWindow, and the explicit-window pre-check."""
+
+import functools
+import pickle
+from collections.abc import Sequence
+
+import attrs
+import pandas as pd
+import pytest
+
+from pysmo import Event, MiniEvent, MiniSeismogram, MiniStation, Seismogram, Station
+from pysmo.tools.project import (
+    FetchContext,
+    PhaseWindow,
+    ProjectEntry,
+    PysmoProject,
+    WindowResult,
+)
+from pysmo.tools.traveltime import travel_times
+
+
+def fake_travel_time_backend(
+    *, depth: float, distance: float, phases: Sequence[str]
+) -> dict[str, pd.Timedelta]:
+    return {"P": pd.Timedelta(seconds=100.0), "S": pd.Timedelta(seconds=200.0)}
+
+
+def no_arrival_travel_time_backend(
+    *, depth: float, distance: float, phases: Sequence[str]
+) -> dict[str, pd.Timedelta]:
+    return {}
+
+
+def fake_fetch_seismogram(
+    station: Station, starttime: pd.Timestamp, endtime: pd.Timestamp
+) -> Seismogram:
+    return MiniSeismogram(
+        begin_time=starttime, delta=pd.Timedelta(seconds=1), data=[1.0, 2.0, 3.0]
+    )
+
+
+def identity_transform[TStation: Station, TEvent: Event](
+    seismogram: Seismogram, context: FetchContext[TStation, TEvent]
+) -> Seismogram:
+    return seismogram
+
+
+class TestWindowResult:
+    def test_construction_and_frozen(self) -> None:
+        t0 = pd.Timestamp("2020-01-01T00:00:00Z")
+        t1 = pd.Timestamp("2020-01-01T00:10:00Z")
+        result = WindowResult(starttime=t0, endtime=t1, reference=None)
+        assert result.starttime == t0
+        assert result.endtime == t1
+        assert result.reference is None
+        with pytest.raises(attrs.exceptions.FrozenInstanceError):
+            result.starttime = t1  # type: ignore[misc]
+
+
+class TestPhaseWindow:
+    def test_window_derived_from_event(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        window = PhaseWindow(travel_time_backend=fake_travel_time_backend)
+        entry = ProjectEntry(station=station_anmo, event=event_maule)
+        result = window(entry)
+
+        expected_reference = event_maule.time + pd.Timedelta(seconds=100.0)
+        assert result.reference == expected_reference
+        assert result.starttime == expected_reference + window.pre_pick
+        assert result.endtime == expected_reference + window.post_pick
+
+    def test_custom_phase(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        window = PhaseWindow(phase="S", travel_time_backend=fake_travel_time_backend)
+        entry = ProjectEntry(station=station_anmo, event=event_maule)
+        result = window(entry)
+        assert result.reference == event_maule.time + pd.Timedelta(seconds=200.0)
+
+    def test_eventless_entry_raises(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        entry = ProjectEntry(station=station_anmo, event=event_maule)
+        entry.event = None
+        window = PhaseWindow(travel_time_backend=fake_travel_time_backend)
+        with pytest.raises(ValueError, match="needs an entry with an event"):
+            window(entry)
+
+    def test_no_predicted_arrival_raises(
+        self, station_anmo: MiniStation, event_maule: MiniEvent
+    ) -> None:
+        window = PhaseWindow(travel_time_backend=no_arrival_travel_time_backend)
+        entry = ProjectEntry(station=station_anmo, event=event_maule)
+        with pytest.raises(ValueError, match="No 'P' arrival predicted"):
+            window(entry)
+
+    def test_equality_and_pickle_round_trip(self) -> None:
+        # Equal when the backend compares equal (a plain function does; the
+        # default `functools.partial` does not, hence the explicit backend).
+        assert PhaseWindow(travel_time_backend=fake_travel_time_backend) == PhaseWindow(
+            travel_time_backend=fake_travel_time_backend
+        )
+        restored = pickle.loads(pickle.dumps(PhaseWindow(phase="S")))
+        assert restored.phase == "S"
+        assert restored.pre_pick == PhaseWindow().pre_pick
+        assert isinstance(restored.travel_time_backend, functools.partial)
+        assert restored.travel_time_backend.func is travel_times
+
+
+class TestPhaseWindowValidators:
+    def test_pre_pick_zero_is_valid(self) -> None:
+        PhaseWindow(pre_pick=pd.Timedelta(0))
+
+    def test_pre_pick_positive_raises(self) -> None:
+        with pytest.raises(ValueError):
+            PhaseWindow(pre_pick=pd.Timedelta(seconds=1))
+
+    def test_post_pick_zero_raises(self) -> None:
+        with pytest.raises(ValueError):
+            PhaseWindow(post_pick=pd.Timedelta(0))
+
+    def test_post_pick_negative_raises(self) -> None:
+        with pytest.raises(ValueError):
+            PhaseWindow(post_pick=pd.Timedelta(seconds=-1))
+
+
+class TestExplicitWindowPreCheck:
+    def test_explicit_window_bypasses_the_resolver(
+        self, station_anmo: MiniStation
+    ) -> None:
+        calls: list[ProjectEntry[MiniStation, MiniEvent]] = []
+
+        def spy_window(entry: ProjectEntry[MiniStation, MiniEvent]) -> WindowResult:
+            calls.append(entry)
+            raise AssertionError("resolver should not be called")
+
+        t0 = pd.Timestamp("2020-01-01T00:00:00Z")
+        t1 = pd.Timestamp("2020-01-01T00:10:00Z")
+        entry = ProjectEntry[MiniStation, MiniEvent](
+            station=station_anmo, starttime=t0, endtime=t1
+        )
+        captured: list[FetchContext[MiniStation, MiniEvent]] = []
+
+        def capture_transform(
+            seismogram: Seismogram, context: FetchContext[MiniStation, MiniEvent]
+        ) -> Seismogram:
+            captured.append(context)
+            return seismogram
+
+        project: PysmoProject[MiniStation, MiniEvent, Seismogram] = PysmoProject(
+            entries=[entry],
+            seismogram_transform=capture_transform,
+            fetch_seismogram=fake_fetch_seismogram,
+            window=spy_window,
+        )
+        project._fetch(entry)
+
+        assert calls == []
+        assert captured[0].starttime == t0
+        assert captured[0].endtime == t1
+        assert captured[0].reference is None


### PR DESCRIPTION
Replace PysmoProject's four window knobs (phase, pre_pick, post_pick, travel_time_backend) with a single `window` callable, defaulting to a new PhaseWindow class that carries them. Add WindowResult and documented type aliases for all three seams (WindowResolver, SeismogramFetcher, SeismogramTransform) in a new _types.py; FetchContext moves there and its `predicted` field becomes `reference`.

The fetch cache is now keyed by entry.identity with the window resolved lazily on a miss, so a cache hit never re-runs the resolver and two coincident explicit windows for different events stay distinct. resolution_context_digest bumps rc1 to rc2; callable_identity recurses into an attrs instance's callable fields. Pickle _FORMAT_VERSION 1 to 2, no migration (the tool is unreleased).

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--316.org.readthedocs.build/en/316/

<!-- readthedocs-preview pysmo end -->