### PR TITLE
feat(project): add optional name label to PysmoProject

### DIFF
--- a/src/pysmo/tools/project/__init__.py
+++ b/src/pysmo/tools/project/__init__.py
@@ -18,7 +18,8 @@ The `PysmoProject` instance is the reproducible, shareable artefact: it is
 pickled, not serialised to a bespoke config format, so its three pluggable
 callables (`window`, `fetch_seismogram`, `seismogram_transform`) must be real
 top-level functions in an importable module rather than lambdas or closures
-(pickle serialises functions by reference, not by value). A callable that
+(pickle serialises functions by reference, not by value). An optional `name`
+labels the project for identification when persisted. A callable that
 needs its own configuration (e.g. filter corner frequencies) should be a
 callable [`attrs`][] class with only picklable fields (see the example below):
 it pickles by value, and its declared fields are what let

--- a/src/pysmo/tools/project/_project.py
+++ b/src/pysmo/tools/project/_project.py
@@ -100,6 +100,11 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
     stored on the instance between calls beyond an in-memory cache of
     already-fetched-and-transformed results.
 
+    An optional `name` can label the project for identification by tools
+    that hold more than one project. It is free-text and carries no
+    semantics: it is not a key, does not affect cache invalidation, and is
+    not part of `resolution_context_digest` or any entry identity.
+
     Generic over the station and event types of its `entries` (matching
     [`ProjectEntry`][pysmo.tools.project.ProjectEntry]'s parameter order)
     and the return type of `seismogram_transform`, all three inferred at
@@ -113,6 +118,12 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
 
     See the [module documentation][pysmo.tools.project] for a worked
     example.
+
+    Note: Persistence
+        A `PysmoProject` travels as a pickle. The in-memory cache and lock
+        are dropped during pickling and reconstructed on unpickling. An
+        optional `name` is preserved across pickles; unpickling a project
+        serialised without a `name` defaults it to `None`.
 
     Note: Thread-safety
         The in-memory fetch cache is safe to touch from multiple threads
@@ -131,6 +142,19 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
     """
 
     _FORMAT_VERSION: ClassVar[int] = 2
+
+    name: str | None = field(
+        default=None,
+        validator=validators.optional(validators.instance_of(str)),
+    )
+    """Optional free-text label for this project.
+
+    Useful for identification by downstream tools that hold multiple
+    projects. This is purely a label, not a key: no uniqueness is enforced,
+    renaming does not invalidate the fetch cache, and it is not part of
+    [`resolution_context_digest`][pysmo.tools.project.PysmoProject.resolution_context_digest]
+    or any entry identity.
+    """
 
     entries: list[ProjectEntry[TStation, TEvent]] = field(
         factory=list, on_setattr=setters.pipe(setters.convert, _on_setattr_clear_cache)
@@ -257,6 +281,7 @@ class PysmoProject[TStation: Station, TEvent: Event, TSeismogram = MiniSeismogra
                 + f"format v{pickled_format}; this pysmo ({__version__}) uses "
                 + f"v{self._FORMAT_VERSION}. Re-create the project."
             )
+        state.setdefault("name", None)
         attrs_setstate(self, state)
         object.__setattr__(self, "_lock", threading.Lock())
 

--- a/tests/tools/project/test_identity.py
+++ b/tests/tools/project/test_identity.py
@@ -8,6 +8,8 @@ from typing import Any
 import attrs
 import pandas as pd
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from pysmo import MiniEvent, MiniSeismogram, MiniStation, Seismogram, Station
 from pysmo.tools.project import (
@@ -454,4 +456,10 @@ class TestResolutionContextDigest:
     def test_digest_excludes_fetch_seismogram(self) -> None:
         p1: ProjectT = PysmoProject(fetch_seismogram=dummy_fetch)
         p2: ProjectT = PysmoProject(fetch_seismogram=another_dummy_fetch)
+        assert resolution_context_digest(p1) == resolution_context_digest(p2)
+
+    @given(st.text() | st.none(), st.text() | st.none())
+    def test_digest_excludes_name(self, name_a: str | None, name_b: str | None) -> None:
+        p1: ProjectT = PysmoProject(name=name_a)
+        p2: ProjectT = PysmoProject(name=name_b)
         assert resolution_context_digest(p1) == resolution_context_digest(p2)

--- a/tests/tools/project/test_project.py
+++ b/tests/tools/project/test_project.py
@@ -11,6 +11,8 @@ from typing import Literal
 
 import pandas as pd
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from pysmo import Event, MiniEvent, MiniSeismogram, MiniStation, Seismogram, Station
 from pysmo.tools.project import (
@@ -193,6 +195,27 @@ class TestQuerySurface:
             seismogram_transform=identity_transform,
         )
         assert project.stations_for(None) == [station_anmo]
+
+    def test_name_defaults_to_none(self) -> None:
+        project: ProjectT = PysmoProject()
+        assert project.name is None
+
+    @given(st.text())
+    def test_name_accepts_any_str(self, name: str) -> None:
+        project: ProjectT = PysmoProject(name=name)
+        assert project.name == name
+
+    @given(
+        st.one_of(
+            st.integers(),
+            st.floats(allow_nan=False),
+            st.binary(),
+            st.lists(st.text()),
+        )
+    )
+    def test_name_rejects_non_str(self, value: object) -> None:
+        with pytest.raises(TypeError):
+            PysmoProject(name=value)  # type: ignore[arg-type]
 
 
 class TestFetchAll:
@@ -439,6 +462,51 @@ class TestCacheInvalidation:
         project.clear_cache()
         assert project._cache_generation == 2
 
+    @given(st.text())
+    def test_renaming_does_not_clear_cache(self, new_name: str) -> None:
+        fetch_count = 0
+
+        def counting_fetch(
+            station: Station, starttime: pd.Timestamp, endtime: pd.Timestamp
+        ) -> Seismogram:
+            nonlocal fetch_count
+            fetch_count += 1
+            return MiniSeismogram(
+                begin_time=starttime, delta=pd.Timedelta(seconds=1), data=[1.0, 2.0]
+            )
+
+        station = MiniStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="LHZ",
+            latitude=34.945981,
+            longitude=-106.457133,
+        )
+        event = MiniEvent(
+            latitude=-36.122,
+            longitude=-72.898,
+            depth=22900.0,
+            time=pd.Timestamp("2010-02-27T06:34:11.53Z"),
+        )
+        project: ProjectT = PysmoProject(
+            entries=[ProjectEntry(station=station, event=event)],
+            seismogram_transform=identity_transform,
+            fetch_seismogram=counting_fetch,  # type: ignore[arg-type]
+            window=phase_window(),
+        )
+        project.seismogram(station, event)
+        assert len(project._cache) == 1
+        assert project._cache_generation == 0
+        assert fetch_count == 1
+
+        project.name = new_name
+        assert len(project._cache) == 1
+        assert project._cache_generation == 0
+
+        project.seismogram(station, event)
+        assert fetch_count == 1  # no re-fetch: cache still intact
+
 
 class TestSeismogramsFor:
     def test_one_result_per_station_in_order(
@@ -605,6 +673,49 @@ class TestPickling:
         del state["_format_version"]
         with pytest.raises(ValueError, match=r"state format v0; this pysmo .* uses v2"):
             project.__setstate__(state)
+
+    @given(st.text() | st.none())
+    def test_name_round_trips_through_pickle(self, name: str | None) -> None:
+        project: ProjectT = PysmoProject(name=name)
+        restored: ProjectT = pickle.loads(pickle.dumps(project))
+        assert restored.name == name
+
+    def test_missing_name_in_state_dict_restores_with_none(self) -> None:
+        project: ProjectT = PysmoProject()
+        state = project.__getstate__()
+        del state["name"]
+        restored = PysmoProject.__new__(PysmoProject)
+        restored.__setstate__(state)
+        assert restored.name is None
+
+    @given(st.text(), st.text())
+    def test_equality_with_name(self, name_a: str, name_b: str) -> None:
+        station = MiniStation(
+            name="ANMO",
+            network="IU",
+            location="00",
+            channel="LHZ",
+            latitude=34.945981,
+            longitude=-106.457133,
+        )
+        event = MiniEvent(
+            latitude=-36.122,
+            longitude=-72.898,
+            depth=22900.0,
+            time=pd.Timestamp("2010-02-27T06:34:11.53Z"),
+        )
+        entries = [ProjectEntry(station=station, event=event)]
+        p_a1 = PysmoProject(name=name_a, entries=entries)
+        p_a2 = PysmoProject(name=name_a, entries=entries)
+        p_b = PysmoProject(name=name_b, entries=entries)
+        p_none = PysmoProject(name=None, entries=entries)
+
+        assert p_a1 == p_a2
+        if name_a == name_b:
+            assert p_a1 == p_b
+        else:
+            assert p_a1 != p_b
+        assert p_a1 != p_none
 
 
 class TestThreadSafety:


### PR DESCRIPTION
Adds a free-text `name` field for identifying projects, with no effect on caching, equality digests, or entry identity. Persists across pickling, defaulting to `None` when absent from older state.

<!-- readthedocs-preview pysmo start -->
----
📚 Documentation preview 📚: https://pysmo--317.org.readthedocs.build/en/317/

<!-- readthedocs-preview pysmo end -->